### PR TITLE
CarpetX: checkpoint and recover per-level iterations for subcycling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .claude/
 thoughts/
 
+.clang-format
+
 *.pyc
 .vscode
 tags

--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -39,6 +39,24 @@ void SetRecoveredLevelIterations(bool value) {
   recovered_level_iterations = value;
 }
 
+struct RecoveredIteration {
+  int patch, level;
+  int64_t num, den;
+};
+static std::vector<RecoveredIteration> recovered_iteration_buffer;
+
+void StoreRecoveredLevelIteration(int patch, int level, int64_t num,
+                                  int64_t den) {
+  recovered_iteration_buffer.push_back({patch, level, num, den});
+}
+
+void ApplyRecoveredLevelIterations() {
+  for (const auto &ri : recovered_iteration_buffer)
+    ghext->patchdata.at(ri.patch).leveldata.at(ri.level).iteration =
+        rat64(ri.num, ri.den);
+  recovered_iteration_buffer.clear();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace {
@@ -136,6 +154,7 @@ void RecoverGridStructure(cGH *restrict cctkGH) {
   DECLARE_CCTK_PARAMETERS;
 
   recovered_level_iterations = false;
+  recovered_iteration_buffer.clear();
 
   if (CCTK_EQUALS(recover_method, "openpmd")) {
 

--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -1,5 +1,5 @@
-#include "driver.hxx"
 #include "io.hxx"
+#include "driver.hxx"
 #include "io_adios2.hxx"
 #include "io_meta.hxx"
 #include "io_norm.hxx"
@@ -30,6 +30,14 @@
 #include <vector>
 
 namespace CarpetX {
+
+static bool recovered_level_iterations = false;
+
+bool HasRecoveredLevelIterations() { return recovered_level_iterations; }
+
+void SetRecoveredLevelIterations(bool value) {
+  recovered_level_iterations = value;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -126,6 +134,8 @@ extern "C" int CarpetX_RecoverParameters() {
 void RecoverGridStructure(cGH *restrict cctkGH) {
   DECLARE_CCTK_ARGUMENTS;
   DECLARE_CCTK_PARAMETERS;
+
+  recovered_level_iterations = false;
 
   if (CCTK_EQUALS(recover_method, "openpmd")) {
 
@@ -367,7 +377,7 @@ void OutputPlotfile(const cGH *restrict cctkGH) {
 struct parameters {};
 YAML::Emitter &operator<<(YAML::Emitter &yaml, parameters) {
   // Collect all parameters and their values
-  std::vector<std::pair<std::string, const cParamData *> > parameter_values;
+  std::vector<std::pair<std::string, const cParamData *>> parameter_values;
   int first = 1;
   for (;;) {
     const cParamData *data;

--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -1,5 +1,5 @@
-#include "io.hxx"
 #include "driver.hxx"
+#include "io.hxx"
 #include "io_adios2.hxx"
 #include "io_meta.hxx"
 #include "io_norm.hxx"
@@ -377,7 +377,7 @@ void OutputPlotfile(const cGH *restrict cctkGH) {
 struct parameters {};
 YAML::Emitter &operator<<(YAML::Emitter &yaml, parameters) {
   // Collect all parameters and their values
-  std::vector<std::pair<std::string, const cParamData *>> parameter_values;
+  std::vector<std::pair<std::string, const cParamData *> > parameter_values;
   int first = 1;
   for (;;) {
     const cParamData *data;

--- a/CarpetX/src/io.hxx
+++ b/CarpetX/src/io.hxx
@@ -11,6 +11,9 @@ void InputGH(const cGH *cctkGH);
 
 int OutputGH(const cGH *cctkGH);
 
+bool HasRecoveredLevelIterations();
+void SetRecoveredLevelIterations(bool value);
+
 } // namespace CarpetX
 
 #endif // #ifndef CARPETX_CARPETX_IO_HXX

--- a/CarpetX/src/io.hxx
+++ b/CarpetX/src/io.hxx
@@ -3,6 +3,8 @@
 
 #include <cctk.h>
 
+#include <cstdint>
+
 namespace CarpetX {
 
 void RecoverGridStructure(cGH *cctkGH);
@@ -13,6 +15,10 @@ int OutputGH(const cGH *cctkGH);
 
 bool HasRecoveredLevelIterations();
 void SetRecoveredLevelIterations(bool value);
+
+void StoreRecoveredLevelIteration(int patch, int level, int64_t num,
+                                  int64_t den);
+void ApplyRecoveredLevelIterations();
 
 } // namespace CarpetX
 

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -687,7 +687,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
               read_iter
                   ->getAttribute("iteration_den" + level_suffixes.at(level))
                   .get<std::int64_t>();
-          patchdata.leveldata.at(level).iteration = rat64(num, den);
+          StoreRecoveredLevelIteration(patch, level, num, den);
         }
         SetRecoveredLevelIterations(true);
       }

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -1,6 +1,7 @@
 #include "io_openpmd.hxx"
 
 #include "driver.hxx"
+#include "io.hxx"
 #include "timer.hxx"
 
 #include <div.hxx>
@@ -341,7 +342,7 @@ struct carpetx_openpmd_t {
       }
       return r;
     }
-    std::vector<box_t<I, D> > grids;
+    std::vector<box_t<I, D>> grids;
     Arith::vect<std::vector<I>, 2> offsets_sizes() const {
       std::vector<I> offsets(grids.size() + 1), sizes(grids.size());
       I offset{0};
@@ -358,7 +359,7 @@ struct carpetx_openpmd_t {
 
   template <typename T, typename I, std::size_t D> struct grid_structure_t {
     box_t<T, D> rdomain;
-    std::vector<level_t<T, I, D> > levels;
+    std::vector<level_t<T, I, D>> levels;
   };
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -607,7 +608,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     assert(read_iter->getAttribute("patchSuffixes").dtype ==
            openPMD::Datatype::VEC_STRING);
     patch_suffixes = read_iter->getAttribute("patchSuffixes")
-                         .get<std::vector<std::string> >();
+                         .get<std::vector<std::string>>();
   }
 
   for (auto &patchdata : ghext->patchdata) {
@@ -630,7 +631,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
                  .dtype == openPMD::Datatype::VEC_STRING);
       level_suffixes =
           read_iter->getAttribute("levelSuffixes" + patch_suffixes.at(patch))
-              .get<std::vector<std::string> >();
+              .get<std::vector<std::string>>();
     }
     assert(int(level_suffixes.size()) == nlevels);
 
@@ -641,7 +642,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     for (int level = 0; level < nlevels; ++level) {
       const std::vector<std::int64_t> chunk_infos =
           read_iter->getAttribute("chunkInfo" + level_suffixes.at(level))
-              .get<std::vector<std::int64_t> >();
+              .get<std::vector<std::int64_t>>();
       assert(chunk_infos.size() % (2 * ndims) == 0);
       const int nfabs = chunk_infos.size() / (2 * ndims);
       amrex::Vector<amrex::Box> levboxes(nfabs);
@@ -672,6 +673,25 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
       patchdata.amrcore->SetupLevel(level, boxarray, dm,
                                     []() { return "Recovering"; });
     } // for level
+
+    // Restore per-level iterations (new checkpoint format)
+    {
+      const std::string test_key = "iteration_num" + level_suffixes.at(0);
+      if (read_iter->containsAttribute(test_key)) {
+        for (int level = 0; level < nlevels; ++level) {
+          const auto num =
+              read_iter
+                  ->getAttribute("iteration_num" + level_suffixes.at(level))
+                  .get<std::int64_t>();
+          const auto den =
+              read_iter
+                  ->getAttribute("iteration_den" + level_suffixes.at(level))
+                  .get<std::int64_t>();
+          patchdata.leveldata.at(level).iteration = rat64(num, den);
+        }
+        SetRecoveredLevelIterations(true);
+      }
+    }
   } // for patch
 }
 
@@ -807,7 +827,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
   }
 
   // Post-read tasks
-  std::vector<std::function<void()> > tasks;
+  std::vector<std::function<void()>> tasks;
 
   // First read grid functions in a loop over patches and levels
 
@@ -962,7 +982,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))> >::max() /
+                      std::remove_reference_t<decltype(start.at(d))>>::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1158,7 +1178,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))> >::max() /
+                     std::remove_reference_t<decltype(start.at(d))>>::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1482,6 +1502,12 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
         }
         write_iter.setAttribute("chunkInfo" + level_suffixes.at(level),
                                 chunk_infos);
+        write_iter.setAttribute<std::int64_t>("iteration_num" +
+                                                  level_suffixes.at(level),
+                                              leveldata.iteration.num);
+        write_iter.setAttribute<std::int64_t>("iteration_den" +
+                                                  level_suffixes.at(level),
+                                              leveldata.iteration.den);
       }
     }
   } // if ioproc
@@ -1686,7 +1712,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))> >::max() /
+                      std::remove_reference_t<decltype(start.at(d))>>::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1853,7 +1879,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))> >::max() /
+                     std::remove_reference_t<decltype(start.at(d))>>::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -342,7 +342,7 @@ struct carpetx_openpmd_t {
       }
       return r;
     }
-    std::vector<box_t<I, D>> grids;
+    std::vector<box_t<I, D> > grids;
     Arith::vect<std::vector<I>, 2> offsets_sizes() const {
       std::vector<I> offsets(grids.size() + 1), sizes(grids.size());
       I offset{0};
@@ -359,7 +359,7 @@ struct carpetx_openpmd_t {
 
   template <typename T, typename I, std::size_t D> struct grid_structure_t {
     box_t<T, D> rdomain;
-    std::vector<level_t<T, I, D>> levels;
+    std::vector<level_t<T, I, D> > levels;
   };
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -608,7 +608,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     assert(read_iter->getAttribute("patchSuffixes").dtype ==
            openPMD::Datatype::VEC_STRING);
     patch_suffixes = read_iter->getAttribute("patchSuffixes")
-                         .get<std::vector<std::string>>();
+                         .get<std::vector<std::string> >();
   }
 
   for (auto &patchdata : ghext->patchdata) {
@@ -631,7 +631,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
                  .dtype == openPMD::Datatype::VEC_STRING);
       level_suffixes =
           read_iter->getAttribute("levelSuffixes" + patch_suffixes.at(patch))
-              .get<std::vector<std::string>>();
+              .get<std::vector<std::string> >();
     }
     assert(int(level_suffixes.size()) == nlevels);
 
@@ -642,7 +642,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     for (int level = 0; level < nlevels; ++level) {
       const std::vector<std::int64_t> chunk_infos =
           read_iter->getAttribute("chunkInfo" + level_suffixes.at(level))
-              .get<std::vector<std::int64_t>>();
+              .get<std::vector<std::int64_t> >();
       assert(chunk_infos.size() % (2 * ndims) == 0);
       const int nfabs = chunk_infos.size() / (2 * ndims);
       amrex::Vector<amrex::Box> levboxes(nfabs);
@@ -827,7 +827,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
   }
 
   // Post-read tasks
-  std::vector<std::function<void()>> tasks;
+  std::vector<std::function<void()> > tasks;
 
   // First read grid functions in a loop over patches and levels
 
@@ -982,7 +982,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))>>::max() /
+                      std::remove_reference_t<decltype(start.at(d))> >::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1178,7 +1178,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))>>::max() /
+                     std::remove_reference_t<decltype(start.at(d))> >::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1712,7 +1712,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))>>::max() /
+                      std::remove_reference_t<decltype(start.at(d))> >::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1879,7 +1879,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))>>::max() /
+                     std::remove_reference_t<decltype(start.at(d))> >::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));

--- a/CarpetX/src/io_silo.cxx
+++ b/CarpetX/src/io_silo.cxx
@@ -1,6 +1,7 @@
 #include "io_silo.hxx"
 
 #include "driver.hxx"
+#include "io.hxx"
 #include "io_meta.hxx"
 #include "mpi_types.hxx"
 #include "timer.hxx"
@@ -447,6 +448,48 @@ void InputSiloGridStructure(cGH *restrict const cctkGH,
     } // for level
   } // for patch
 
+  // Read per-level iteration (new checkpoint format)
+  {
+    int total_levels = 0;
+    for (int p = 0; p < npatches; ++p)
+      total_levels += nlevels.at(p);
+
+    bool has_iteration_data = false;
+    std::vector<long long> iter_nums(total_levels);
+    std::vector<long long> iter_dens(total_levels);
+
+    if (read_metafile) {
+      const std::string varname =
+          dirname + "/" + DB::legalize_name("iteration_num");
+      const int vartype = DBGetVarType(metafile.get(), varname.c_str());
+      if (vartype == DB_LONG_LONG) {
+        has_iteration_data = true;
+        ierr = DBReadVar(metafile.get(), varname.c_str(), iter_nums.data());
+        assert(!ierr);
+        const std::string den_varname =
+            dirname + "/" + DB::legalize_name("iteration_den");
+        ierr = DBReadVar(metafile.get(), den_varname.c_str(), iter_dens.data());
+        assert(!ierr);
+      }
+    }
+    MPI_Bcast(&has_iteration_data, 1, MPI_C_BOOL, metafile_ioproc, mpi_comm);
+
+    if (has_iteration_data) {
+      MPI_Bcast(iter_nums.data(), total_levels, MPI_LONG_LONG, metafile_ioproc,
+                mpi_comm);
+      MPI_Bcast(iter_dens.data(), total_levels, MPI_LONG_LONG, metafile_ioproc,
+                mpi_comm);
+      int idx = 0;
+      for (int patch = 0; patch < npatches; ++patch)
+        for (int level = 0; level < nlevels.at(patch); ++level) {
+          ghext->patchdata.at(patch).leveldata.at(level).iteration =
+              rat64(iter_nums.at(idx), iter_dens.at(idx));
+          ++idx;
+        }
+      SetRecoveredLevelIterations(true);
+    }
+  }
+
   interval_meta = nullptr;
 }
 
@@ -753,7 +796,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
   auto interval_data = std::make_unique<Interval>(timer_data);
 
   // Global coordinate extents for each component
-  std::vector<std::vector<std::vector<std::array<CCTK_REAL, dim> > > >
+  std::vector<std::vector<std::vector<std::array<CCTK_REAL, dim>>>>
       coordinate_minima, coordinate_maxima;
 
   // Write data
@@ -1186,8 +1229,8 @@ void OutputSilo(const cGH *restrict const cctkGH,
         const int npatches = ghext->num_patches();
         std::vector<int> comp0_level(nlevels);
         std::vector<int> ncomps_level(nlevels);
-        std::vector<std::vector<int> > comp0_level_patch(nlevels);
-        std::vector<std::vector<int> > ncomps_level_patch(nlevels);
+        std::vector<std::vector<int>> comp0_level_patch(nlevels);
+        std::vector<std::vector<int>> ncomps_level_patch(nlevels);
         for (int level = 0; level < nlevels; ++level) {
           comp0_level_patch.at(level).resize(npatches, 0);
           ncomps_level_patch.at(level).resize(npatches, 0);
@@ -1216,7 +1259,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
         const std::string levelmaps_name = multimeshname + "_wmrgtree_lvlMaps";
         {
           std::vector<int> segment_types;
-          std::vector<std::vector<int> > segment_data;
+          std::vector<std::vector<int>> segment_data;
           segment_types.reserve(nlevels);
           segment_data.reserve(nlevels);
           for (int l = 0; l < nlevels; ++l) {
@@ -1251,7 +1294,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
         std::vector<int> num_children;
         {
           std::vector<int> segment_types;
-          std::vector<std::vector<int> > segment_data;
+          std::vector<std::vector<int>> segment_data;
           segment_types.reserve(ncomps_total);
           segment_data.reserve(ncomps_total);
 
@@ -1276,7 +1319,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
                   const amrex::Box &box = mfab.box(component); // interior
                   amrex::Box refined_box(box);
                   refined_box.refine(2);
-                  const std::vector<pair<int, amrex::Box> > child_boxes =
+                  const std::vector<pair<int, amrex::Box>> child_boxes =
                       fine_boxarray.intersections(refined_box);
                   std::vector<int> children;
                   children.reserve(child_boxes.size());
@@ -1799,6 +1842,38 @@ void OutputSilo(const cGH *restrict const cctkGH,
               make_fabarraybasename(patchdata.patch, leveldata.level);
           ierr = DBWrite(metafile.get(), varname.c_str(), boxes.data(), dims, 2,
                          DB_INT);
+          assert(!ierr);
+        }
+      }
+
+      // Write per-level iteration (numerator and denominator)
+      {
+        int total_levels = 0;
+        for (const auto &patchdata : ghext->patchdata)
+          total_levels += int(patchdata.leveldata.size());
+
+        std::vector<long long> iter_nums(total_levels);
+        std::vector<long long> iter_dens(total_levels);
+        int idx = 0;
+        for (const auto &patchdata : ghext->patchdata)
+          for (const auto &leveldata : patchdata.leveldata) {
+            iter_nums.at(idx) = leveldata.iteration.num;
+            iter_dens.at(idx) = leveldata.iteration.den;
+            ++idx;
+          }
+
+        {
+          const std::string varname =
+              dirname + "/" + DB::legalize_name("iteration_num");
+          ierr = DBWrite(metafile.get(), varname.c_str(), iter_nums.data(),
+                         &total_levels, 1, DB_LONG_LONG);
+          assert(!ierr);
+        }
+        {
+          const std::string varname =
+              dirname + "/" + DB::legalize_name("iteration_den");
+          ierr = DBWrite(metafile.get(), varname.c_str(), iter_dens.data(),
+                         &total_levels, 1, DB_LONG_LONG);
           assert(!ierr);
         }
       }

--- a/CarpetX/src/io_silo.cxx
+++ b/CarpetX/src/io_silo.cxx
@@ -796,7 +796,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
   auto interval_data = std::make_unique<Interval>(timer_data);
 
   // Global coordinate extents for each component
-  std::vector<std::vector<std::vector<std::array<CCTK_REAL, dim>>>>
+  std::vector<std::vector<std::vector<std::array<CCTK_REAL, dim> > > >
       coordinate_minima, coordinate_maxima;
 
   // Write data
@@ -1229,8 +1229,8 @@ void OutputSilo(const cGH *restrict const cctkGH,
         const int npatches = ghext->num_patches();
         std::vector<int> comp0_level(nlevels);
         std::vector<int> ncomps_level(nlevels);
-        std::vector<std::vector<int>> comp0_level_patch(nlevels);
-        std::vector<std::vector<int>> ncomps_level_patch(nlevels);
+        std::vector<std::vector<int> > comp0_level_patch(nlevels);
+        std::vector<std::vector<int> > ncomps_level_patch(nlevels);
         for (int level = 0; level < nlevels; ++level) {
           comp0_level_patch.at(level).resize(npatches, 0);
           ncomps_level_patch.at(level).resize(npatches, 0);
@@ -1259,7 +1259,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
         const std::string levelmaps_name = multimeshname + "_wmrgtree_lvlMaps";
         {
           std::vector<int> segment_types;
-          std::vector<std::vector<int>> segment_data;
+          std::vector<std::vector<int> > segment_data;
           segment_types.reserve(nlevels);
           segment_data.reserve(nlevels);
           for (int l = 0; l < nlevels; ++l) {
@@ -1294,7 +1294,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
         std::vector<int> num_children;
         {
           std::vector<int> segment_types;
-          std::vector<std::vector<int>> segment_data;
+          std::vector<std::vector<int> > segment_data;
           segment_types.reserve(ncomps_total);
           segment_data.reserve(ncomps_total);
 
@@ -1319,7 +1319,7 @@ void OutputSilo(const cGH *restrict const cctkGH,
                   const amrex::Box &box = mfab.box(component); // interior
                   amrex::Box refined_box(box);
                   refined_box.refine(2);
-                  const std::vector<pair<int, amrex::Box>> child_boxes =
+                  const std::vector<pair<int, amrex::Box> > child_boxes =
                       fine_boxarray.intersections(refined_box);
                   std::vector<int> children;
                   children.reserve(child_boxes.size());

--- a/CarpetX/src/io_silo.cxx
+++ b/CarpetX/src/io_silo.cxx
@@ -482,8 +482,8 @@ void InputSiloGridStructure(cGH *restrict const cctkGH,
       int idx = 0;
       for (int patch = 0; patch < npatches; ++patch)
         for (int level = 0; level < nlevels.at(patch); ++level) {
-          ghext->patchdata.at(patch).leveldata.at(level).iteration =
-              rat64(iter_nums.at(idx), iter_dens.at(idx));
+          StoreRecoveredLevelIteration(patch, level, iter_nums.at(idx),
+                                       iter_dens.at(idx));
           ++idx;
         }
       SetRecoveredLevelIterations(true);

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -2156,7 +2156,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
     const std::vector<clause_t> &writes =
         decode_clauses(attribute, rdwr_t::write);
     const int numgroups = CCTK_NumGroups();
-    std::vector<std::vector<std::vector<valid_t>>> gfs(numgroups);
+    std::vector<std::vector<std::vector<valid_t> > > gfs(numgroups);
     for (int gi = 0; gi < numgroups; ++gi) {
       const int numvars = CCTK_NumVarsInGroupI(gi);
       gfs.at(gi).resize(numvars);

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -1132,8 +1132,7 @@ int Initialise(tFleshConfig *config) {
     CCTK_Traverse(cctkGH, "CCTK_POST_RECOVER_VARIABLES");
 
     if (HasRecoveredLevelIterations()) {
-      // Per-level iterations were restored from checkpoint metadata
-      // by InputOpenPMDGridStructure / InputSiloGridStructure.
+      ApplyRecoveredLevelIterations();
     } else {
       // Fallback for old checkpoints without per-level iteration data.
       // Assumes all levels have caught up to the coarsest one.

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -1131,13 +1131,17 @@ int Initialise(tFleshConfig *config) {
     CCTK_Traverse(cctkGH, "CCTK_RECOVER_VARIABLES");
     CCTK_Traverse(cctkGH, "CCTK_POST_RECOVER_VARIABLES");
 
-    // Here we assume that all levels have catched up to the coarsed one when
-    // checkpointing.
-    // TODO: checkpoint level.iteration instead.
-    const int iteration_ratio = pow(2, ghext->num_levels() - 1);
-    active_levels->loop_serially([&](auto &restrict leveldata) {
-      leveldata.iteration = rat64(cctkGH->cctk_iteration) / iteration_ratio;
-    });
+    if (HasRecoveredLevelIterations()) {
+      // Per-level iterations were restored from checkpoint metadata
+      // by InputOpenPMDGridStructure / InputSiloGridStructure.
+    } else {
+      // Fallback for old checkpoints without per-level iteration data.
+      // Assumes all levels have caught up to the coarsest one.
+      const int iteration_ratio = pow(2, ghext->num_levels() - 1);
+      active_levels->loop_serially([&](auto &restrict leveldata) {
+        leveldata.iteration = rat64(cctkGH->cctk_iteration) / iteration_ratio;
+      });
+    }
 
     active_levels = optional<active_levels_t>();
 


### PR DESCRIPTION
@rhaas80 @yosef-zlochower Store each level's iteration numerator and denominator in both OpenPMD and Silo checkpoint files. On recovery, restore these values directly instead of assuming all levels have caught up to the coarsest level. Old checkpoints without this data still work via the existing fallback.