### PR TITLE
CarpetX: add per-level iteration metadata to checkpoints

### DIFF
--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -142,7 +142,7 @@ struct GHExt {
     bool do_checkpoint; // whether to checkpoint
     bool do_restrict;   // whether to restrict
 
-    std::vector<std::vector<why_valid_t>> valid; // [time level][var index]
+    std::vector<std::vector<why_valid_t> > valid; // [time level][var index]
 
     // TODO: add poison_invalid and check_valid functions
 
@@ -322,7 +322,7 @@ struct GHExt {
                                        const ArrayGroupData &arraygroupdata);
     };
     // TODO: right now this is sized for the total number of groups
-    std::vector<std::unique_ptr<ArrayGroupData>>
+    std::vector<std::unique_ptr<ArrayGroupData> >
         arraygroupdata; // [group index]
 
     friend YAML::Emitter &operator<<(YAML::Emitter &yaml,
@@ -402,7 +402,7 @@ struct GHExt {
 
         std::array<std::array<boundary_t, dim>, 2> boundaries;
         bool all_faces_have_symmetries_or_boundaries() const;
-        std::vector<array<int, dim>> parities;
+        std::vector<array<int, dim> > parities;
         std::vector<CCTK_REAL> dirichlet_values;
         std::vector<CCTK_REAL> robin_values;
         amrex::Vector<amrex::BCRec> bcrecs;
@@ -411,7 +411,7 @@ struct GHExt {
         void apply_boundary_conditions(amrex::MultiFab &mfab) const;
 
         // each amrex::MultiFab has numvars components
-        std::vector<std::unique_ptr<amrex::MultiFab>> mfab; // [time level]
+        std::vector<std::unique_ptr<amrex::MultiFab> > mfab; // [time level]
 
         // flux register between this and the next coarser level
         std::unique_ptr<amrex::FluxRegister> freg;
@@ -427,7 +427,7 @@ struct GHExt {
         // changes). This is used e.g. by ODESolvers for its
         // temporaries.
       private:
-        mutable std::vector<std::unique_ptr<amrex::MultiFab>> tmp_mfabs;
+        mutable std::vector<std::unique_ptr<amrex::MultiFab> > tmp_mfabs;
         mutable std::size_t next_tmp_mfab;
 
       public:
@@ -439,7 +439,7 @@ struct GHExt {
                                          const GroupData &groupdata);
       };
       // TODO: right now this is sized for the total number of groups
-      std::vector<unique_ptr<GroupData>> groupdata; // [group index]
+      std::vector<unique_ptr<GroupData> > groupdata; // [group index]
 
       friend YAML::Emitter &operator<<(YAML::Emitter &yaml,
                                        const LevelData &leveldata);
@@ -458,7 +458,7 @@ struct GHExt {
     rat64 iteration;
     rat64 delta_iteration;
   };
-  std::optional<std::vector<std::vector<RecoveredIterationData>>>
+  std::optional<std::vector<std::vector<RecoveredIterationData> > >
       recovered_level_iterations; // [patch][level]
 
   int num_patches() const { return patchdata.size(); }

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <type_traits>
 #include <vector>
@@ -141,7 +142,7 @@ struct GHExt {
     bool do_checkpoint; // whether to checkpoint
     bool do_restrict;   // whether to restrict
 
-    std::vector<std::vector<why_valid_t> > valid; // [time level][var index]
+    std::vector<std::vector<why_valid_t>> valid; // [time level][var index]
 
     // TODO: add poison_invalid and check_valid functions
 
@@ -321,7 +322,7 @@ struct GHExt {
                                        const ArrayGroupData &arraygroupdata);
     };
     // TODO: right now this is sized for the total number of groups
-    std::vector<std::unique_ptr<ArrayGroupData> >
+    std::vector<std::unique_ptr<ArrayGroupData>>
         arraygroupdata; // [group index]
 
     friend YAML::Emitter &operator<<(YAML::Emitter &yaml,
@@ -401,7 +402,7 @@ struct GHExt {
 
         std::array<std::array<boundary_t, dim>, 2> boundaries;
         bool all_faces_have_symmetries_or_boundaries() const;
-        std::vector<array<int, dim> > parities;
+        std::vector<array<int, dim>> parities;
         std::vector<CCTK_REAL> dirichlet_values;
         std::vector<CCTK_REAL> robin_values;
         amrex::Vector<amrex::BCRec> bcrecs;
@@ -410,7 +411,7 @@ struct GHExt {
         void apply_boundary_conditions(amrex::MultiFab &mfab) const;
 
         // each amrex::MultiFab has numvars components
-        std::vector<std::unique_ptr<amrex::MultiFab> > mfab; // [time level]
+        std::vector<std::unique_ptr<amrex::MultiFab>> mfab; // [time level]
 
         // flux register between this and the next coarser level
         std::unique_ptr<amrex::FluxRegister> freg;
@@ -426,7 +427,7 @@ struct GHExt {
         // changes). This is used e.g. by ODESolvers for its
         // temporaries.
       private:
-        mutable std::vector<std::unique_ptr<amrex::MultiFab> > tmp_mfabs;
+        mutable std::vector<std::unique_ptr<amrex::MultiFab>> tmp_mfabs;
         mutable std::size_t next_tmp_mfab;
 
       public:
@@ -438,7 +439,7 @@ struct GHExt {
                                          const GroupData &groupdata);
       };
       // TODO: right now this is sized for the total number of groups
-      std::vector<unique_ptr<GroupData> > groupdata; // [group index]
+      std::vector<unique_ptr<GroupData>> groupdata; // [group index]
 
       friend YAML::Emitter &operator<<(YAML::Emitter &yaml,
                                        const LevelData &leveldata);
@@ -449,6 +450,16 @@ struct GHExt {
                                      const PatchData &patchdata);
   };
   std::vector<PatchData> patchdata; // [patch]
+
+  // Recovered per-level iteration metadata from checkpoint (temporary).
+  // Present only during recovery of a checkpoint that contains per-level
+  // metadata. Cleared after use in Initialise().
+  struct RecoveredIterationData {
+    rat64 iteration;
+    rat64 delta_iteration;
+  };
+  std::optional<std::vector<std::vector<RecoveredIterationData>>>
+      recovered_level_iterations; // [patch][level]
 
   int num_patches() const { return patchdata.size(); }
   int num_levels(const int patch) const {

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -341,7 +341,7 @@ struct carpetx_openpmd_t {
       }
       return r;
     }
-    std::vector<box_t<I, D> > grids;
+    std::vector<box_t<I, D>> grids;
     Arith::vect<std::vector<I>, 2> offsets_sizes() const {
       std::vector<I> offsets(grids.size() + 1), sizes(grids.size());
       I offset{0};
@@ -358,7 +358,7 @@ struct carpetx_openpmd_t {
 
   template <typename T, typename I, std::size_t D> struct grid_structure_t {
     box_t<T, D> rdomain;
-    std::vector<level_t<T, I, D> > levels;
+    std::vector<level_t<T, I, D>> levels;
   };
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -607,7 +607,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     assert(read_iter->getAttribute("patchSuffixes").dtype ==
            openPMD::Datatype::VEC_STRING);
     patch_suffixes = read_iter->getAttribute("patchSuffixes")
-                         .get<std::vector<std::string> >();
+                         .get<std::vector<std::string>>();
   }
 
   for (auto &patchdata : ghext->patchdata) {
@@ -630,7 +630,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
                  .dtype == openPMD::Datatype::VEC_STRING);
       level_suffixes =
           read_iter->getAttribute("levelSuffixes" + patch_suffixes.at(patch))
-              .get<std::vector<std::string> >();
+              .get<std::vector<std::string>>();
     }
     assert(int(level_suffixes.size()) == nlevels);
 
@@ -641,7 +641,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     for (int level = 0; level < nlevels; ++level) {
       const std::vector<std::int64_t> chunk_infos =
           read_iter->getAttribute("chunkInfo" + level_suffixes.at(level))
-              .get<std::vector<std::int64_t> >();
+              .get<std::vector<std::int64_t>>();
       assert(chunk_infos.size() % (2 * ndims) == 0);
       const int nfabs = chunk_infos.size() / (2 * ndims);
       amrex::Vector<amrex::Box> levboxes(nfabs);
@@ -671,6 +671,28 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
 
       patchdata.amrcore->SetupLevel(level, boxarray, dm,
                                     []() { return "Recovering"; });
+
+      // Read per-level iteration metadata if present (new checkpoint format)
+      const std::string iter_attr = "levelIteration" + level_suffixes.at(level);
+      if (read_iter->containsAttribute(iter_attr)) {
+        if (!ghext->recovered_level_iterations) {
+          ghext->recovered_level_iterations.emplace();
+          ghext->recovered_level_iterations->resize(ghext->num_patches());
+        }
+        auto &patch_vec = ghext->recovered_level_iterations->at(patch);
+        if (int(patch_vec.size()) < nlevels)
+          patch_vec.resize(nlevels);
+
+        const auto iter_vec =
+            read_iter->getAttribute(iter_attr).get<std::vector<std::int64_t>>();
+        const auto diter_vec =
+            read_iter
+                ->getAttribute("levelDeltaIteration" + level_suffixes.at(level))
+                .get<std::vector<std::int64_t>>();
+
+        patch_vec.at(level) = {rat64(iter_vec.at(0), iter_vec.at(1)),
+                               rat64(diter_vec.at(0), diter_vec.at(1))};
+      }
     } // for level
   } // for patch
 }
@@ -807,7 +829,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
   }
 
   // Post-read tasks
-  std::vector<std::function<void()> > tasks;
+  std::vector<std::function<void()>> tasks;
 
   // First read grid functions in a loop over patches and levels
 
@@ -962,7 +984,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))> >::max() /
+                      std::remove_reference_t<decltype(start.at(d))>>::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1158,7 +1180,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))> >::max() /
+                     std::remove_reference_t<decltype(start.at(d))>>::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1482,6 +1504,16 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
         }
         write_iter.setAttribute("chunkInfo" + level_suffixes.at(level),
                                 chunk_infos);
+
+        // Write per-level iteration metadata for subcycling recovery
+        write_iter.setAttribute(
+            "levelIteration" + level_suffixes.at(level),
+            std::vector<std::int64_t>{leveldata.iteration.num,
+                                      leveldata.iteration.den});
+        write_iter.setAttribute(
+            "levelDeltaIteration" + level_suffixes.at(level),
+            std::vector<std::int64_t>{leveldata.delta_iteration.num,
+                                      leveldata.delta_iteration.den});
       }
     }
   } // if ioproc
@@ -1686,7 +1718,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))> >::max() /
+                      std::remove_reference_t<decltype(start.at(d))>>::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1853,7 +1885,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))> >::max() /
+                     std::remove_reference_t<decltype(start.at(d))>>::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -341,7 +341,7 @@ struct carpetx_openpmd_t {
       }
       return r;
     }
-    std::vector<box_t<I, D>> grids;
+    std::vector<box_t<I, D> > grids;
     Arith::vect<std::vector<I>, 2> offsets_sizes() const {
       std::vector<I> offsets(grids.size() + 1), sizes(grids.size());
       I offset{0};
@@ -358,7 +358,7 @@ struct carpetx_openpmd_t {
 
   template <typename T, typename I, std::size_t D> struct grid_structure_t {
     box_t<T, D> rdomain;
-    std::vector<level_t<T, I, D>> levels;
+    std::vector<level_t<T, I, D> > levels;
   };
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -607,7 +607,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     assert(read_iter->getAttribute("patchSuffixes").dtype ==
            openPMD::Datatype::VEC_STRING);
     patch_suffixes = read_iter->getAttribute("patchSuffixes")
-                         .get<std::vector<std::string>>();
+                         .get<std::vector<std::string> >();
   }
 
   for (auto &patchdata : ghext->patchdata) {
@@ -630,7 +630,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
                  .dtype == openPMD::Datatype::VEC_STRING);
       level_suffixes =
           read_iter->getAttribute("levelSuffixes" + patch_suffixes.at(patch))
-              .get<std::vector<std::string>>();
+              .get<std::vector<std::string> >();
     }
     assert(int(level_suffixes.size()) == nlevels);
 
@@ -641,7 +641,7 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
     for (int level = 0; level < nlevels; ++level) {
       const std::vector<std::int64_t> chunk_infos =
           read_iter->getAttribute("chunkInfo" + level_suffixes.at(level))
-              .get<std::vector<std::int64_t>>();
+              .get<std::vector<std::int64_t> >();
       assert(chunk_infos.size() % (2 * ndims) == 0);
       const int nfabs = chunk_infos.size() / (2 * ndims);
       amrex::Vector<amrex::Box> levboxes(nfabs);
@@ -683,12 +683,12 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
         if (int(patch_vec.size()) < nlevels)
           patch_vec.resize(nlevels);
 
-        const auto iter_vec =
-            read_iter->getAttribute(iter_attr).get<std::vector<std::int64_t>>();
+        const auto iter_vec = read_iter->getAttribute(iter_attr)
+                                  .get<std::vector<std::int64_t> >();
         const auto diter_vec =
             read_iter
                 ->getAttribute("levelDeltaIteration" + level_suffixes.at(level))
-                .get<std::vector<std::int64_t>>();
+                .get<std::vector<std::int64_t> >();
 
         patch_vec.at(level) = {rat64(iter_vec.at(0), iter_vec.at(1)),
                                rat64(diter_vec.at(0), diter_vec.at(1))};
@@ -829,7 +829,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
   }
 
   // Post-read tasks
-  std::vector<std::function<void()>> tasks;
+  std::vector<std::function<void()> > tasks;
 
   // First read grid functions in a loop over patches and levels
 
@@ -984,7 +984,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))>>::max() /
+                      std::remove_reference_t<decltype(start.at(d))> >::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1180,7 +1180,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))>>::max() /
+                     std::remove_reference_t<decltype(start.at(d))> >::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1718,7 +1718,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
               assert(
                   start.at(d) <
                   std::numeric_limits<
-                      std::remove_reference_t<decltype(start.at(d))>>::max() /
+                      std::remove_reference_t<decltype(start.at(d))> >::max() /
                       2);
             for (int d = 0; d < 3; ++d)
               assert(start.at(d) + count.at(d) <= extent.at(d));
@@ -1885,7 +1885,7 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
           // assert(start.at(d) >= 0);
           assert(start.at(d) <
                  std::numeric_limits<
-                     std::remove_reference_t<decltype(start.at(d))>>::max() /
+                     std::remove_reference_t<decltype(start.at(d))> >::max() /
                      2);
         for (int d = 0; d < 3; ++d)
           assert(start.at(d) + count.at(d) <= extent.at(d));

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -1131,13 +1131,23 @@ int Initialise(tFleshConfig *config) {
     CCTK_Traverse(cctkGH, "CCTK_RECOVER_VARIABLES");
     CCTK_Traverse(cctkGH, "CCTK_POST_RECOVER_VARIABLES");
 
-    // Here we assume that all levels have catched up to the coarsed one when
-    // checkpointing.
-    // TODO: checkpoint level.iteration instead.
-    const int iteration_ratio = pow(2, ghext->num_levels() - 1);
-    active_levels->loop_serially([&](auto &restrict leveldata) {
-      leveldata.iteration = rat64(cctkGH->cctk_iteration) / iteration_ratio;
-    });
+    if (ghext->recovered_level_iterations) {
+      // New checkpoint format: restore per-level iteration values
+      active_levels->loop_serially([&](auto &restrict leveldata) {
+        const auto &data =
+            ghext->recovered_level_iterations->at(leveldata.patch)
+                .at(leveldata.level);
+        leveldata.iteration = data.iteration;
+        leveldata.delta_iteration = data.delta_iteration;
+      });
+      ghext->recovered_level_iterations.reset();
+    } else {
+      // Old checkpoint format: assume all levels synchronized
+      const int iteration_ratio = pow(2, ghext->num_levels() - 1);
+      active_levels->loop_serially([&](auto &restrict leveldata) {
+        leveldata.iteration = rat64(cctkGH->cctk_iteration) / iteration_ratio;
+      });
+    }
 
     active_levels = optional<active_levels_t>();
 


### PR DESCRIPTION
Serialize per-level iteration and delta_iteration as OpenPMD attributes during checkpoint, and restore them during recovery. This enables correct checkpoint/recover when refinement levels are at different time steps during a subcycling sweep. Old checkpoints without these attributes use the existing fallback.