### PR TITLE
CarpetX: add do_evolve tag and checkpoint per-level iterations

### DIFF
--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -333,6 +333,28 @@ bool get_group_checkpoint_flag(const int gi) {
   }
 }
 
+bool get_group_evolve_flag(const int gi) {
+  int tags = CCTK_GroupTagsTableI(gi);
+  assert(tags >= 0);
+  char buf[100];
+  int iret = Util_TableGetString(tags, sizeof buf, buf, "evolve");
+  if (iret == UTIL_ERROR_TABLE_NO_SUCH_KEY) {
+    // Default: do_evolve = do_checkpoint (backward compatible)
+    return get_group_checkpoint_flag(gi);
+  } else if (iret >= 0) {
+    std::string str(buf);
+    for (auto &c : str)
+      c = tolower(c);
+    if (str == "yes")
+      return true;
+    if (str == "no")
+      return false;
+    assert(0);
+  } else {
+    assert(0);
+  }
+}
+
 bool get_group_restrict_flag(const int gi) {
   int tags = CCTK_GroupTagsTableI(gi);
   assert(tags >= 0);
@@ -823,6 +845,7 @@ GHExt::PatchData::LevelData::GroupData::GroupData(
   firstvarindex = CCTK_FirstVarIndexI(gi);
   numvars = group.numvars;
   do_checkpoint = get_group_checkpoint_flag(gi);
+  do_evolve = get_group_evolve_flag(gi);
   do_restrict = get_group_restrict_flag(gi);
   indextype = get_group_indextype(gi);
   nghostzones = get_group_nghostzones(gi);
@@ -1098,6 +1121,7 @@ void SetupGlobals() {
     arraygroupdata.firstvarindex = CCTK_FirstVarIndexI(gi);
     arraygroupdata.numvars = group.numvars;
     arraygroupdata.do_checkpoint = get_group_checkpoint_flag(gi);
+    arraygroupdata.do_evolve = get_group_evolve_flag(gi);
     arraygroupdata.do_restrict = get_group_restrict_flag(gi);
 
     CCTK_INT const *const *const sz = CCTK_GroupSizesI(gi);
@@ -1129,7 +1153,7 @@ void SetupGlobals() {
     }
 
     // Allocate data
-    const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
+    const nan_handling_t nan_handling = arraygroupdata.do_evolve
                                             ? nan_handling_t::forbid_nans
                                             : nan_handling_t::allow_nans;
     arraygroupdata.data.resize(group.numtimelevels);
@@ -1265,8 +1289,8 @@ void CactusAmrCore::MakeNewLevelFromCoarse(
     // We only prolongate the state vector. And if there is more than
     // one time level, then we don't prolongate the oldest.
     const int prolongate_tl =
-        groupdata.do_checkpoint ? (ntls > 1 ? ntls - 1 : ntls) : 0;
-    const nan_handling_t nan_handling = groupdata.do_checkpoint
+        groupdata.do_evolve ? (ntls > 1 ? ntls - 1 : ntls) : 0;
+    const nan_handling_t nan_handling = groupdata.do_evolve
                                             ? nan_handling_t::forbid_nans
                                             : nan_handling_t::allow_nans;
 
@@ -1370,8 +1394,8 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
     // We only prolongate the state vector. And if there is more than
     // one time level, then we don't prolongate the oldest.
     const int prolongate_tl =
-        groupdata.do_checkpoint ? (ntls > 1 ? ntls - 1 : ntls) : 0;
-    const nan_handling_t nan_handling = groupdata.do_checkpoint
+        groupdata.do_evolve ? (ntls > 1 ? ntls - 1 : ntls) : 0;
+    const nan_handling_t nan_handling = groupdata.do_evolve
                                             ? nan_handling_t::forbid_nans
                                             : nan_handling_t::allow_nans;
 
@@ -1431,7 +1455,7 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
                                  : valid_t();
     assert(outer_valid == make_valid_outer());
 
-    const nan_handling_t nan_handling = groupdata.do_checkpoint
+    const nan_handling_t nan_handling = groupdata.do_evolve
                                             ? nan_handling_t::forbid_nans
                                             : nan_handling_t::allow_nans;
 
@@ -1439,7 +1463,7 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
     // We only prolongate the state vector. And if there is more than
     // one time level, then we don't prolongate the oldest.
     const int prolongate_tl =
-        groupdata.do_checkpoint ? (ntls > 1 ? ntls - 1 : ntls) : 0;
+        groupdata.do_evolve ? (ntls > 1 ? ntls - 1 : ntls) : 0;
 
     for (int tl = 0; tl < ntls; ++tl) {
       if (tl < prolongate_tl) {
@@ -1642,6 +1666,7 @@ YAML::Emitter &operator<<(YAML::Emitter &yaml,
   yaml << YAML::EndSeq;
   yaml << YAML::Key << "do_checkpoint" << YAML::Value
        << commongroupdata.do_checkpoint;
+  yaml << YAML::Key << "do_evolve" << YAML::Value << commongroupdata.do_evolve;
   yaml << YAML::Key << "do_restrict" << YAML::Value
        << commongroupdata.do_restrict;
   yaml << YAML::Key << "valid" << YAML::Value << commongroupdata.valid;

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -139,6 +139,8 @@ struct GHExt {
     int numvars;
 
     bool do_checkpoint; // whether to checkpoint
+    bool do_evolve;     // whether this is an evolved variable (restrict, sync,
+                        // prolongation, NaN)
     bool do_restrict;   // whether to restrict
 
     std::vector<std::vector<why_valid_t> > valid; // [time level][var index]
@@ -449,6 +451,11 @@ struct GHExt {
                                      const PatchData &patchdata);
   };
   std::vector<PatchData> patchdata; // [patch]
+
+  // Side storage for per-level iterations recovered from checkpoint.
+  // Populated by RecoverGridStructure, consumed by recovery code.
+  // Indexed as [patch][level]. Empty means old checkpoint (uniform fallback).
+  std::vector<std::vector<rat64> > recovered_iterations;
 
   bool use_subcycling = false;
 

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -671,6 +671,20 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
 
       patchdata.amrcore->SetupLevel(level, boxarray, dm,
                                     []() { return "Recovering"; });
+
+      // Read per-level iteration if present (new checkpoint format)
+      const std::string iter_attr = "iteration" + level_suffixes.at(level);
+      if (read_iter->containsAttribute(iter_attr)) {
+        if (ghext->recovered_iterations.empty())
+          ghext->recovered_iterations.resize(ghext->num_patches());
+        auto &patch_iters = ghext->recovered_iterations.at(patch);
+        if (int(patch_iters.size()) <= level)
+          patch_iters.resize(level + 1);
+        const auto iter_vec = read_iter->getAttribute(iter_attr)
+                                  .get<std::vector<std::int64_t> >();
+        assert(iter_vec.size() == 2);
+        patch_iters.at(level) = rat64(iter_vec[0], iter_vec[1]);
+      }
     } // for level
   } // for patch
 }
@@ -1482,6 +1496,12 @@ void carpetx_openpmd_t::OutputOpenPMD(const cGH *const cctkGH,
         }
         write_iter.setAttribute("chunkInfo" + level_suffixes.at(level),
                                 chunk_infos);
+        // Write per-level iteration as {numerator, denominator}
+        const std::vector<std::int64_t> iter_rational = {
+            static_cast<std::int64_t>(leveldata.iteration.num),
+            static_cast<std::int64_t>(leveldata.iteration.den)};
+        write_iter.setAttribute("iteration" + level_suffixes.at(level),
+                                iter_rational);
       }
     }
   } // if ioproc

--- a/CarpetX/src/io_silo.cxx
+++ b/CarpetX/src/io_silo.cxx
@@ -444,6 +444,41 @@ void InputSiloGridStructure(cGH *restrict const cctkGH,
 
       patchdata.amrcore->SetupLevel(level, boxarray, dm,
                                     []() { return "Recovering"; });
+
+      // Read per-level iteration if present (new checkpoint format)
+      {
+        std::ostringstream buf;
+        buf << "iteration"
+            << ".m" << std::setw(4) << std::setfill('0') << patch << ".rl"
+            << std::setw(2) << std::setfill('0') << level;
+        const std::string iter_varname =
+            dirname + "/" + DB::legalize_name(buf.str());
+        std::int64_t iter_data[2];
+        bool have_iter = false;
+        if (read_metafile) {
+          const int vartype =
+              DBGetVarType(metafile.get(), iter_varname.c_str());
+          if (vartype == DB_LONG_LONG) {
+            const int varlength =
+                DBGetVarLength(metafile.get(), iter_varname.c_str());
+            if (varlength == 2) {
+              ierr = DBReadVar(metafile.get(), iter_varname.c_str(), iter_data);
+              assert(!ierr);
+              have_iter = true;
+            }
+          }
+        }
+        MPI_Bcast(&have_iter, 1, MPI_C_BOOL, metafile_ioproc, mpi_comm);
+        if (have_iter) {
+          MPI_Bcast(iter_data, 2, MPI_INT64_T, metafile_ioproc, mpi_comm);
+          if (ghext->recovered_iterations.empty())
+            ghext->recovered_iterations.resize(ghext->num_patches());
+          auto &patch_iters = ghext->recovered_iterations.at(patch);
+          if (int(patch_iters.size()) <= level)
+            patch_iters.resize(level + 1);
+          patch_iters.at(level) = rat64(iter_data[0], iter_data[1]);
+        }
+      }
     } // for level
   } // for patch
 
@@ -1799,6 +1834,25 @@ void OutputSilo(const cGH *restrict const cctkGH,
               make_fabarraybasename(patchdata.patch, leveldata.level);
           ierr = DBWrite(metafile.get(), varname.c_str(), boxes.data(), dims, 2,
                          DB_INT);
+          assert(!ierr);
+        }
+      }
+
+      // Write per-level iteration as {numerator, denominator}
+      for (const auto &patchdata : ghext->patchdata) {
+        for (const auto &leveldata : patchdata.leveldata) {
+          std::int64_t iter_data[2] = {
+              static_cast<std::int64_t>(leveldata.iteration.num),
+              static_cast<std::int64_t>(leveldata.iteration.den)};
+          const int dims = 2;
+          std::ostringstream buf;
+          buf << "iteration"
+              << ".m" << std::setw(4) << std::setfill('0') << patchdata.patch
+              << ".rl" << std::setw(2) << std::setfill('0') << leveldata.level;
+          const std::string varname =
+              dirname + "/" + DB::legalize_name(buf.str());
+          ierr = DBWrite(metafile.get(), varname.c_str(), iter_data, &dims, 1,
+                         DB_LONG_LONG);
           assert(!ierr);
         }
       }

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -1145,13 +1145,24 @@ int Initialise(tFleshConfig *config) {
     CCTK_Traverse(cctkGH, "CCTK_RECOVER_VARIABLES");
     CCTK_Traverse(cctkGH, "CCTK_POST_RECOVER_VARIABLES");
 
-    // Here we assume that all levels have caught up to the coarsest one when
-    // checkpointing.
-    // TODO: checkpoint level.iteration instead.
-    const int iteration_ratio = 1 << (ghext->num_levels() - 1);
-    active_levels->loop_serially([&](auto &restrict leveldata) {
-      leveldata.iteration = rat64(cctkGH->cctk_iteration) / iteration_ratio;
-    });
+    if (!ghext->recovered_iterations.empty()) {
+      // New checkpoint format: restore per-level iteration from checkpoint
+      active_levels->loop_serially([&](auto &restrict leveldata) {
+        leveldata.iteration =
+            ghext->recovered_iterations.at(leveldata.patch).at(leveldata.level);
+      });
+      CCTK_VINFO("Recovered per-level iterations from checkpoint");
+      ghext->recovered_iterations.clear();
+    } else {
+      // Old checkpoint format: assume all levels were synchronized
+      // TODO: remove this fallback once all checkpoints use the new format
+      const int iteration_ratio = 1 << (ghext->num_levels() - 1);
+      active_levels->loop_serially([&](auto &restrict leveldata) {
+        leveldata.iteration = rat64(cctkGH->cctk_iteration) / iteration_ratio;
+      });
+      CCTK_VINFO("No per-level iterations in checkpoint; using uniform "
+                 "formula (legacy fallback)");
+    }
 
     active_levels = optional<active_levels_t>();
 
@@ -1380,22 +1391,24 @@ int Initialise(tFleshConfig *config) {
   assert(!active_levels);
   active_levels = make_optional<active_levels_t>();
 
-  if (!restrict_during_sync) {
-    // Restrict
-    assert(active_levels);
-    active_levels->loop_fine_to_coarse([&](const auto &leveldata) {
-      if (leveldata.level != ghext->num_levels() - 1)
-        Restrict(cctkGH, leveldata.level);
-    });
-    // Prolongation
-    SyncEvolvedGFs(cctkGH);
-    CCTK_Traverse(cctkGH, "CCTK_POSTRESTRICT");
-  }
+  if (!config->recovered) {
+    if (!restrict_during_sync) {
+      // Restrict
+      assert(active_levels);
+      active_levels->loop_fine_to_coarse([&](const auto &leveldata) {
+        if (leveldata.level != ghext->num_levels() - 1)
+          Restrict(cctkGH, leveldata.level);
+      });
+      // Prolongation
+      SyncEvolvedGFs(cctkGH);
+      CCTK_Traverse(cctkGH, "CCTK_POSTRESTRICT");
+    }
 
-  // Checkpoint, analysis, output
-  CCTK_Traverse(cctkGH, "CCTK_POSTSTEP");
-  CCTK_Traverse(cctkGH, "CCTK_CPINITIAL");
-  CCTK_Traverse(cctkGH, "CCTK_ANALYSIS");
+    // Checkpoint, analysis, output
+    CCTK_Traverse(cctkGH, "CCTK_POSTSTEP");
+    CCTK_Traverse(cctkGH, "CCTK_CPINITIAL");
+    CCTK_Traverse(cctkGH, "CCTK_ANALYSIS");
+  }
   CCTK_OutputGH(cctkGH);
 
   active_levels = optional<active_levels_t>();
@@ -1466,7 +1479,7 @@ void InvalidateTimelevels(cGH *restrict const cctkGH) {
       const auto &patchdata0 = ghext->patchdata.at(0);
       const auto &leveldata0 = patchdata0.leveldata.at(0);
       const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-      if (!groupdata0.do_checkpoint) {
+      if (!groupdata0.do_evolve) {
         const int ntls0 = groupdata0.mfab.size();
         assert(active_levels);
         active_levels->loop_serially([&](const auto &restrict leveldata) {
@@ -1490,7 +1503,7 @@ void InvalidateTimelevels(cGH *restrict const cctkGH) {
 
       auto &restrict globaldata = ghext->globaldata;
       auto &restrict arraygroupdata = *globaldata.arraygroupdata.at(gi);
-      if (!arraygroupdata.do_checkpoint) {
+      if (!arraygroupdata.do_evolve) {
         // Invalidate all time levels
         const int ntls = arraygroupdata.data.size();
         for (int tl = 0; tl < ntls; ++tl)
@@ -1532,7 +1545,7 @@ void CycleTimelevels(cGH *restrict const cctkGH) {
       const auto &leveldata0 = patchdata0.leveldata.at(0);
       const auto &groupdata0 = *leveldata0.groupdata.at(gi);
       const int ntls0 = groupdata0.mfab.size();
-      const nan_handling_t nan_handling = groupdata0.do_checkpoint
+      const nan_handling_t nan_handling = groupdata0.do_evolve
                                               ? nan_handling_t::forbid_nans
                                               : nan_handling_t::allow_nans;
 
@@ -1553,8 +1566,8 @@ void CycleTimelevels(cGH *restrict const cctkGH) {
             });
         }
         // All time levels (except the current) must be valid everywhere for
-        // checkpointed groups
-        if (groupdata.do_checkpoint) {
+        // evolved groups
+        if (groupdata.do_evolve) {
           for (int tl = (ntls == 1 ? 0 : 1); tl < ntls; ++tl) {
             // it is only possible to sync time-level zero
             if (tl == 0 && presync_only) {
@@ -1580,7 +1593,7 @@ void CycleTimelevels(cGH *restrict const cctkGH) {
 
       auto &restrict globaldata = ghext->globaldata;
       auto &restrict arraygroupdata = *globaldata.arraygroupdata.at(gi);
-      const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
+      const nan_handling_t nan_handling = arraygroupdata.do_evolve
                                               ? nan_handling_t::forbid_nans
                                               : nan_handling_t::allow_nans;
       const int ntls = arraygroupdata.data.size();
@@ -2065,7 +2078,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
         const auto &patchdata0 = ghext->patchdata.at(0);
         const auto &leveldata0 = patchdata0.leveldata.at(0);
         const auto &groupdata0 = *leveldata0.groupdata.at(rd.gi);
-        const nan_handling_t nan_handling = groupdata0.do_checkpoint
+        const nan_handling_t nan_handling = groupdata0.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
 
@@ -2094,7 +2107,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
 
         const auto &restrict arraygroupdata =
             *ghext->globaldata.arraygroupdata.at(rd.gi);
-        const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
+        const nan_handling_t nan_handling = arraygroupdata.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
         const valid_t &need = rd.valid;
@@ -2247,7 +2260,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
         const auto &patchdata0 = ghext->patchdata.at(0);
         const auto &leveldata0 = patchdata0.leveldata.at(0);
         const auto &groupdata0 = *leveldata0.groupdata.at(wr.gi);
-        const nan_handling_t nan_handling = groupdata0.do_checkpoint
+        const nan_handling_t nan_handling = groupdata0.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
 
@@ -2278,7 +2291,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
       } else { // CCTK_ARRAY or CCTK_SCALAR
         auto &restrict arraygroupdata =
             *ghext->globaldata.arraygroupdata.at(wr.gi);
-        const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
+        const nan_handling_t nan_handling = arraygroupdata.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
         const valid_t &provided = wr.valid;
@@ -2313,7 +2326,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
         const auto &patchdata0 = ghext->patchdata.at(0);
         const auto &leveldata0 = patchdata0.leveldata.at(0);
         const auto &groupdata0 = *leveldata0.groupdata.at(inv.gi);
-        const nan_handling_t nan_handling = groupdata0.do_checkpoint
+        const nan_handling_t nan_handling = groupdata0.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
 
@@ -2344,7 +2357,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
       } else { // CCTK_ARRAY or CCTK_SCALAR
         auto &restrict arraygroupdata =
             *ghext->globaldata.arraygroupdata.at(inv.gi);
-        const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
+        const nan_handling_t nan_handling = arraygroupdata.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
         const valid_t &invalidated = inv.valid;
@@ -2478,7 +2491,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
     const auto &patchdata0 = ghext->patchdata.at(0);
     const auto &leveldata0 = patchdata0.leveldata.at(0);
     const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-    const nan_handling_t nan_handling = groupdata0.do_checkpoint
+    const nan_handling_t nan_handling = groupdata0.do_evolve
                                             ? nan_handling_t::forbid_nans
                                             : nan_handling_t::allow_nans;
     // We always sync all directions.
@@ -2627,7 +2640,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
     const auto &patchdata0 = ghext->patchdata.at(0);
     const auto &leveldata0 = patchdata0.leveldata.at(0);
     const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-    const nan_handling_t nan_handling = groupdata0.do_checkpoint
+    const nan_handling_t nan_handling = groupdata0.do_evolve
                                             ? nan_handling_t::forbid_nans
                                             : nan_handling_t::allow_nans;
     // We always sync all directions.
@@ -2680,7 +2693,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
       const auto &patchdata0 = ghext->patchdata.at(0);
       const auto &leveldata0 = patchdata0.leveldata.at(0);
       const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-      const nan_handling_t nan_handling = groupdata0.do_checkpoint
+      const nan_handling_t nan_handling = groupdata0.do_evolve
                                               ? nan_handling_t::forbid_nans
                                               : nan_handling_t::allow_nans;
       // We always sync all directions.
@@ -2834,7 +2847,7 @@ int SyncGroupsByDirINoRestrict(const cGH *restrict cctkGH, int numgroups,
       const auto &patchdata0 = ghext->patchdata.at(0);
       const auto &leveldata0 = patchdata0.leveldata.at(0);
       const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-      const nan_handling_t nan_handling = groupdata0.do_checkpoint
+      const nan_handling_t nan_handling = groupdata0.do_evolve
                                               ? nan_handling_t::forbid_nans
                                               : nan_handling_t::allow_nans;
       // We always sync all directions.
@@ -2984,7 +2997,7 @@ int SyncGroupsByDirIProlongateOnly(const cGH *restrict cctkGH, int numgroups,
       const auto &patchdata0 = ghext->patchdata.at(0);
       const auto &leveldata0 = patchdata0.leveldata.at(0);
       const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-      const nan_handling_t nan_handling = groupdata0.do_checkpoint
+      const nan_handling_t nan_handling = groupdata0.do_evolve
                                               ? nan_handling_t::forbid_nans
                                               : nan_handling_t::allow_nans;
       // We always sync all directions.
@@ -3106,7 +3119,7 @@ int SyncGroupsByDirIGhostOnly(const cGH *restrict cctkGH, int numgroups,
       const auto &patchdata0 = ghext->patchdata.at(0);
       const auto &leveldata0 = patchdata0.leveldata.at(0);
       const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-      const nan_handling_t nan_handling = groupdata0.do_checkpoint
+      const nan_handling_t nan_handling = groupdata0.do_evolve
                                               ? nan_handling_t::forbid_nans
                                               : nan_handling_t::allow_nans;
       // We always sync all directions.
@@ -3159,7 +3172,7 @@ void Reflux(const cGH *cctkGH, int level) {
 
         auto &groupdata = *leveldata.groupdata.at(gi);
         const auto &finegroupdata = *fineleveldata.groupdata.at(gi);
-        const nan_handling_t nan_handling = groupdata.do_checkpoint
+        const nan_handling_t nan_handling = groupdata.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
 
@@ -3253,7 +3266,7 @@ void Restrict(const cGH *cctkGH, int level, const vector<int> &groups) {
         auto &groupdata = *leveldata.groupdata.at(gi);
         const auto &finegroupdata = *fineleveldata.groupdata.at(gi);
         const amrex::IntVect reffact{2, 2, 2};
-        const nan_handling_t nan_handling = groupdata.do_checkpoint
+        const nan_handling_t nan_handling = groupdata.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
 
@@ -3372,7 +3385,7 @@ void RestrictNoPoison(const cGH *cctkGH, int level, const vector<int> &groups) {
         auto &groupdata = *leveldata.groupdata.at(gi);
         const auto &finegroupdata = *fineleveldata.groupdata.at(gi);
         const amrex::IntVect reffact{2, 2, 2};
-        const nan_handling_t nan_handling = groupdata.do_checkpoint
+        const nan_handling_t nan_handling = groupdata.do_evolve
                                                 ? nan_handling_t::forbid_nans
                                                 : nan_handling_t::allow_nans;
 
@@ -3452,7 +3465,7 @@ void Restrict(const cGH *cctkGH, int level) {
     if (groupdataptr) {
       auto &restrict groupdata = *groupdataptr;
       // Restrict only evolved grid functions
-      if (groupdata.do_checkpoint)
+      if (groupdata.do_evolve)
         groups.push_back(groupdata.groupindex);
     }
   }
@@ -3470,7 +3483,7 @@ void SyncEvolvedGFs(const cGH *cctkGH) {
     if (groupdataptr) {
       auto &restrict groupdata = *groupdataptr;
       // Sync only evolved grid functions
-      if (groupdata.do_checkpoint)
+      if (groupdata.do_evolve)
         groups.push_back(groupdata.groupindex);
     }
   }

--- a/TestSubcyclingMC/interface.ccl
+++ b/TestSubcyclingMC/interface.ccl
@@ -14,31 +14,31 @@ CCTK_REAL ustate TYPE=gf CENTERING={vvv} TAGS='dependents="uerror"'
   rho
 } "Scalar wave state vector"
 
-CCTK_REAL pstate TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL pstate TYPE=gf TAGS='evolve="no"'
 {
   u_p
   rho_p
 } "Scalar wave old state vector"
 
-CCTK_REAL k1 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k1 TYPE=gf TAGS='evolve="no"'
 {
     u_k1
     rho_k1
 } "The Runge-Kutta k_1 variables"
 
-CCTK_REAL k2 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k2 TYPE=gf TAGS='evolve="no"'
 {
     u_k2
     rho_k2
 } "The Runge-Kutta k_2 variables"
 
-CCTK_REAL k3 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k3 TYPE=gf TAGS='evolve="no"'
 {
     u_k3
     rho_k3
 } "The Runge-Kutta k_3 variables"
 
-CCTK_REAL k4 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k4 TYPE=gf TAGS='evolve="no"'
 {
     u_k4
     rho_k4

--- a/TestSubcyclingMC2/interface.ccl
+++ b/TestSubcyclingMC2/interface.ccl
@@ -17,7 +17,7 @@ CCTK_REAL state TYPE=gf TAGS='rhs="rhs" dependents="error"'
   rho
 } "Scalar wave state vector"
 
-CCTK_REAL old TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL old TYPE=gf TAGS='evolve="no"'
 {
   u_old
   rho_old
@@ -29,25 +29,25 @@ CCTK_REAL rhs TYPE=gf TAGS='checkpoint="no"'
   rho_rhs
 } "RHS of scalar wave state vector"
 
-CCTK_REAL k1 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k1 TYPE=gf TAGS='evolve="no"'
 {
     u_k1
     rho_k1
 } "The Runge-Kutta k_1 variables"
 
-CCTK_REAL k2 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k2 TYPE=gf TAGS='evolve="no"'
 {
     u_k2
     rho_k2
 } "The Runge-Kutta k_2 variables"
 
-CCTK_REAL k3 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k3 TYPE=gf TAGS='evolve="no"'
 {
     u_k3
     rho_k3
 } "The Runge-Kutta k_3 variables"
 
-CCTK_REAL k4 TYPE=gf TAGS='checkpoint="no"'
+CCTK_REAL k4 TYPE=gf TAGS='evolve="no"'
 {
     u_k4
     rho_k4


### PR DESCRIPTION
Introduce a new "evolve" group tag to separate evolution semantics (restrict, sync, prolongation, NaN checks) from the checkpoint flag. Save and restore per-level iterations in OpenPMD and Silo checkpoints to support recovering subcycling runs. Skip post-init restrict and analysis when recovering since the data is already consistent.