### PR TITLE
ODESolvers: read old and ks tags explicitly instead of deriving from rhs

### DIFF
--- a/ODESolvers/src/odesolvers_solve_subcycling.cxx
+++ b/ODESolvers/src/odesolvers_solve_subcycling.cxx
@@ -40,6 +40,21 @@ extern "C" void ODESolvers_Solve_Subcycling(CCTK_ARGUMENTS) {
       const int rhs_gi = get_group_rhs(groupdata.groupindex);
       const int old_gi = get_group_old(groupdata.groupindex);
       const auto &ks_gi = get_group_ks<int, rkstages>(groupdata.groupindex);
+      if (rhs_gi >= 0 && old_gi < 0)
+        CCTK_VERROR("Variable group \"%s\" declares rhs but is missing "
+                    "required subcycling tag old=\"...\". Add old=\"...\" "
+                    "to the group's TAGS in interface.ccl.",
+                    CCTK_FullGroupName(groupdata.groupindex));
+      if (rhs_gi >= 0) {
+        for (int i = 0; i < rkstages; i++) {
+          if (ks_gi[i] < 0)
+            CCTK_VERROR("Variable group \"%s\" declares rhs but is missing "
+                        "required subcycling tag ks=\"...\". Add "
+                        "ks=\"k1 k2 k3 k4\" to the group's TAGS in "
+                        "interface.ccl.",
+                        CCTK_FullGroupName(groupdata.groupindex));
+        }
+      }
       if (rhs_gi >= 0) {
         assert(rhs_gi != groupdata.groupindex);
         auto &rhs_groupdata = *leveldata.groupdata.at(rhs_gi);

--- a/ODESolvers/src/solve.hxx
+++ b/ODESolvers/src/solve.hxx
@@ -189,41 +189,40 @@ inline int get_group_old(const int gi) {
   assert(gi >= 0);
   const int tags = CCTK_GroupTagsTableI(gi);
   assert(tags >= 0);
-  std::vector<char> rhs_buf(1000);
+  std::vector<char> old_buf(1000);
   const int iret =
-      Util_TableGetString(tags, rhs_buf.size(), rhs_buf.data(), "rhs");
+      Util_TableGetString(tags, old_buf.size(), old_buf.data(), "old");
   if (iret == UTIL_ERROR_TABLE_NO_SUCH_KEY) {
-    rhs_buf[0] = '\0'; // default: empty (no RHS)
+    old_buf[0] = '\0'; // default: empty (no old)
   } else if (iret >= 0) {
     // do nothing
   } else {
     assert(0);
   }
 
-  std::string str(rhs_buf.data());
+  const std::string str(old_buf.data());
   if (str.empty())
-    return -1; // No RHS specified
-  std::size_t pos = str.find("rhs");
-  str.replace(pos, 3, "old");
-  const int old = groupindex(gi, str);
-  if (old < 0)
-    CCTK_VERROR("Variable group \"%s\" declares a OLD group \"%s\". "
+    return -1; // No old specified
+
+  const int old_gi = groupindex(gi, str);
+  if (old_gi < 0)
+    CCTK_VERROR("Variable group \"%s\" declares an old group \"%s\". "
                 "That group does not exist.",
                 CCTK_FullGroupName(gi), str.c_str());
-  assert(old != gi);
+  assert(old_gi != gi);
 
-  return old;
+  return old_gi;
 }
 
 template <typename T, int D> inline array<T, D> get_group_ks(const int gi) {
   assert(gi >= 0);
   const int tags = CCTK_GroupTagsTableI(gi);
   assert(tags >= 0);
-  std::vector<char> rhs_buf(1000);
+  std::vector<char> ks_buf(1000);
   const int iret =
-      Util_TableGetString(tags, rhs_buf.size(), rhs_buf.data(), "rhs");
+      Util_TableGetString(tags, ks_buf.size(), ks_buf.data(), "ks");
   if (iret == UTIL_ERROR_TABLE_NO_SUCH_KEY) {
-    rhs_buf[0] = '\0'; // default: empty (no RHS)
+    ks_buf[0] = '\0'; // default: empty (no ks)
   } else if (iret >= 0) {
     // do nothing
   } else {
@@ -231,20 +230,42 @@ template <typename T, int D> inline array<T, D> get_group_ks(const int gi) {
   }
 
   array<T, D> ks;
-  const std::string str(rhs_buf.data());
+  ks.fill(-1);
+  const std::string str(ks_buf.data());
   if (str.empty())
-    return array<T, D>{-1}; // No RHS specified
-  std::size_t pos = str.find("rhs");
-  for (int i = 0; i < D; i++) {
-    std::string str_ks = str;
-    str_ks.replace(pos, 3, "k" + std::to_string(i + 1));
-    const int ks_gi = groupindex(gi, str_ks);
+    return ks; // No ks specified
+
+  int count = 0;
+  std::size_t pos = 0;
+  for (;;) {
+    // Skip white space
+    while (pos < str.size() && std::isspace(str[pos]))
+      ++pos;
+    if (pos == str.size())
+      break;
+    // Read group name
+    const std::size_t group_begin = pos;
+    while (pos < str.size() && !std::isspace(str[pos]))
+      ++pos;
+    const std::size_t group_end = pos;
+    const std::string groupname =
+        str.substr(group_begin, group_end - group_begin);
+    const int ks_gi = groupindex(gi, groupname);
     if (ks_gi < 0)
       CCTK_VERROR("Variable group \"%s\" declares a ks group \"%s\". "
                   "That group does not exist.",
-                  CCTK_FullGroupName(gi), str.c_str());
-    ks[i] = ks_gi;
+                  CCTK_FullGroupName(gi), groupname.c_str());
+    if (count >= D)
+      CCTK_VERROR("Variable group \"%s\" declares more than %d ks groups "
+                  "in its TAGS. Expected exactly %d.",
+                  CCTK_FullGroupName(gi), D, D);
+    ks[count] = ks_gi;
+    ++count;
   }
+  if (count != D)
+    CCTK_VERROR("Variable group \"%s\" declares %d ks groups in its TAGS. "
+                "Expected exactly %d.",
+                CCTK_FullGroupName(gi), count, D);
 
   return ks;
 }

--- a/TestSubcyclingMC2/interface.ccl
+++ b/TestSubcyclingMC2/interface.ccl
@@ -11,7 +11,7 @@ USES INCLUDE HEADER: derivs.hxx
 
 
 
-CCTK_REAL state TYPE=gf TAGS='rhs="rhs" dependents="error"'
+CCTK_REAL state TYPE=gf TAGS='rhs="rhs" old="old" ks="k1 k2 k3 k4" dependents="error"'
 {
   u
   rho


### PR DESCRIPTION
Instead of reading the rhs tag and replacing "rhs" in the group name to find old and ks groups, read the old and ks tags directly from the interface.ccl TAGS. This makes the tag interface explicit and adds validation to catch missing old or ks tags when rhs is specified.