### PR TITLE
ODESolvers: copy rhs to ks via AMReX MultiFab::Copy

### DIFF
--- a/ODESolvers/src/odesolvers_solve_subcycling.cxx
+++ b/ODESolvers/src/odesolvers_solve_subcycling.cxx
@@ -1,6 +1,8 @@
 #include "solve.hxx"
 #include <subcycling.hxx>
 
+#include <AMReX_MultiFab.H>
+
 namespace ODESolvers {
 
 constexpr int rkstages = 4;
@@ -238,17 +240,25 @@ extern "C" void ODESolvers_Solve_Subcycling(CCTK_ARGUMENTS) {
       CCTK_VINFO(
           "Set interior Ks for stage #%d at t=%g, to be prolongated later",
           stage, double(cctkGH->cctk_time));
-    active_levels->loop_parallel([&](int patch, int level, int index,
-                                     int component, const cGH *local_cctkGH) {
-      update_cctkGH(const_cast<cGH *>(local_cctkGH), cctkGH);
-      Subcycling::SetK<rkstages>(const_cast<cGH *>(local_cctkGH), ks_groups,
-                                 rhs_groups, stage);
+    const int s = stage - 1;
+    active_levels->loop_coarse_to_fine([&](const auto &restrict leveldata) {
+      for (size_t i = 0; i < rhs_groups.size(); ++i) {
+        const auto &rhs_groupdata = *leveldata.groupdata.at(rhs_groups[i]);
+        const auto &k_groupdata = *leveldata.groupdata.at(ks_groups[s][i]);
+        auto &rhs_mf = *rhs_groupdata.mfab.at(0);
+        auto &k_mf = *k_groupdata.mfab.at(0);
+        assert(k_mf.ixType() == rhs_mf.ixType());
+        assert(k_mf.nComp() == rhs_mf.nComp());
+        assert(k_mf.nGrowVect().allGE(amrex::IntVect(0)));
+        assert(rhs_mf.nGrowVect().allGE(amrex::IntVect(0)));
+        amrex::MultiFab::Copy(k_mf, rhs_mf, 0, 0, k_mf.nComp(),
+                              amrex::IntVect(0));
+      }
     });
     synchronize();
 
     // apply boundary condition to account for mesh refinement overlapping the
     // outer boundary
-    const int s = stage - 1;
     SyncGroupsByDirIGhostOnly(cctkGH, ks_groups[s].size(), ks_groups[s].data(),
                               nullptr);
   };

--- a/Subcycling/src/subcycling.hxx
+++ b/Subcycling/src/subcycling.hxx
@@ -283,45 +283,6 @@ CalcYfFromKcs(CCTK_ARGUMENTS, vector<int> &vars,
                                        /*u0_tl=*/1, kcss, dtc, xsi, stage);
 }
 
-CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
-SetStateInterior(const Loop::GridDescBaseDevice &grid,
-                 const array<int, Loop::dim> &indextype,
-                 const Loop::GF3D2<CCTK_REAL> &u,
-                 const Loop::GF3D2<const CCTK_REAL> &var) {
-  grid.loop_device_idx<Loop::where_t::interior>(
-      indextype, grid.nghostzones,
-      [=] CCTK_DEVICE(const Loop::PointDesc &p)
-          CCTK_ATTRIBUTE_ALWAYS_INLINE { u(p.I) = var(p.I); });
-}
-
-/* Varlist version */
-template <int RKSTAGES>
-CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
-SetK(CCTK_ARGUMENTS, const array<vector<int>, RKSTAGES> &kss, vector<int> &rhss,
-     const CCTK_INT stage) {
-  assert(stage > 0 && stage <= 4);
-  const Loop::GridDescBaseDevice grid(cctkGH);
-  const int tl = 0;
-
-  for (size_t i = 0; i < rhss.size(); ++i) {
-    const int nvars = CCTK_NumVarsInGroupI(rhss[i]);
-    const array<int, Loop::dim> indextype = get_group_indextype(rhss[i]);
-    const Loop::GF3D2layout layout(cctkGH, indextype);
-
-    const int rhs_0 = CCTK_FirstVarIndexI(rhss[i]);
-    const int k_0 = CCTK_FirstVarIndexI(kss[stage - 1][i]);
-    for (int vi = 0; vi < nvars; ++vi) {
-      const Loop::GF3D2<CCTK_REAL> K(
-          layout,
-          static_cast<CCTK_REAL *>(CCTK_VarDataPtrI(cctkGH, tl, k_0 + vi)));
-      const Loop::GF3D2<const CCTK_REAL> rhs(
-          layout,
-          static_cast<CCTK_REAL *>(CCTK_VarDataPtrI(cctkGH, tl, rhs_0 + vi)));
-      SetStateInterior(grid, indextype, K, rhs);
-    }
-  }
-}
-
 } // namespace Subcycling
 
 #endif // #ifndef CARPETX_SUBCYCLING_SUBCYCLING_HXX


### PR DESCRIPTION
Replace the per-component GF3D2 loop (Subcycling::SetK) with a direct amrex::MultiFab::Copy over the level hierarchy. Drop the now-unused SetK and SetStateInterior helpers from Subcycling/subcycling.hxx.