### PR TITLE
Subcycling: warm cf-mask cache single-threaded to avoid MFIter race

### DIFF
--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -932,45 +932,58 @@ GHExt::PatchData::LevelData::GroupData::GroupData(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-amrex::iMultiFab *GHExt::PatchData::LevelData::get_cf_mask(
+void GHExt::PatchData::LevelData::build_cf_mask(
     const std::array<int, dim> &indextype,
     const std::array<int, dim> &nghostzones) const {
   // Nothing to mask at the coarsest level or outside subcycling runs.
+  if (level == 0 || !ghext->use_subcycling)
+    return;
+
+  const int s = (indextype[0] << 2) | (indextype[1] << 1) | indextype[2];
+  if (cf_masks[s])
+    return; // already built (idempotent: warm-up runs every step)
+
+  const amrex::IntVect ng(nghostzones[0], nghostzones[1], nghostzones[2]);
+  const amrex::BoxArray gba = amrex::convert(
+      fab->boxArray(),
+      amrex::IndexType(
+          indextype[0] ? amrex::IndexType::CELL : amrex::IndexType::NODE,
+          indextype[1] ? amrex::IndexType::CELL : amrex::IndexType::NODE,
+          indextype[2] ? amrex::IndexType::CELL : amrex::IndexType::NODE));
+
+  auto mask = std::make_unique<amrex::iMultiFab>(gba, fab->DistributionMap(),
+                                                 /*ncomp=*/1, ng);
+  const auto &geom = ghext->patchdata.at(patch).amrcore->Geom(level);
+  // covered=0  : ghosts filled by same-level FillBoundary (intra-/inter-
+  //              process and periodic-image — see getFB(ngrow, period)
+  //              overlay in AMReX_FabArray.H).
+  // notcovered : coarse-fine prolongation ghosts. Set to cf_ghost (truthy).
+  // physbnd=0  : physical-outer boundary ghosts.
+  // interior=0 : not read by the consumer (loop_device_idx<ghosts>).
+  mask->BuildMask(geom.Domain(), geom.periodicity(),
+                  /*covered=*/0,
+                  /*notcovered=*/cf_ghost,
+                  /*physbnd=*/0,
+                  /*interior=*/0);
+  cf_masks[s] = std::move(mask);
+}
+
+amrex::iMultiFab *GHExt::PatchData::LevelData::get_cf_mask(
+    const std::array<int, dim> &indextype,
+    const std::array<int, dim> &nghostzones) const {
+  // Pure reader: no MFIter, no cache store, so concurrent reads are safe.
+  // The slot must have been warmed single-threaded via build_cf_mask; an
+  // un-warmed centering is a missing warm-up and trips the assert below.
   if (level == 0 || !ghext->use_subcycling)
     return nullptr;
 
   const int s = (indextype[0] << 2) | (indextype[1] << 1) | indextype[2];
   const amrex::IntVect ng(nghostzones[0], nghostzones[1], nghostzones[2]);
-
-  if (!cf_masks[s]) {
-    const amrex::BoxArray gba = amrex::convert(
-        fab->boxArray(),
-        amrex::IndexType(
-            indextype[0] ? amrex::IndexType::CELL : amrex::IndexType::NODE,
-            indextype[1] ? amrex::IndexType::CELL : amrex::IndexType::NODE,
-            indextype[2] ? amrex::IndexType::CELL : amrex::IndexType::NODE));
-
-    auto mask = std::make_unique<amrex::iMultiFab>(gba, fab->DistributionMap(),
-                                                   /*ncomp=*/1, ng);
-    const auto &geom = ghext->patchdata.at(patch).amrcore->Geom(level);
-    // covered=0  : ghosts filled by same-level FillBoundary (intra-/inter-
-    //              process and periodic-image — see getFB(ngrow, period)
-    //              overlay in AMReX_FabArray.H).
-    // notcovered : coarse-fine prolongation ghosts. Set to cf_ghost (truthy).
-    // physbnd=0  : physical-outer boundary ghosts.
-    // interior=0 : not read by the consumer (loop_device_idx<ghosts>).
-    mask->BuildMask(geom.Domain(), geom.periodicity(),
-                    /*covered=*/0,
-                    /*notcovered=*/cf_ghost,
-                    /*physbnd=*/0,
-                    /*interior=*/0);
-    cf_masks[s] = std::move(mask);
-  }
-
-  // Sharing assumption: all groups of this centering at this level use the
-  // same nghostzones. If this assert ever trips, widen the cache key from
-  // `centering` to `(centering, nghost)` inside this function.
-  assert(cf_masks[s]->nGrowVect() == ng);
+  // Slot must be warm (build_cf_mask ran single-threaded). Sharing assumption:
+  // all groups of this centering at this level use the same nghostzones; if the
+  // nGrowVect check trips, widen the cache key from `centering` to
+  // `(centering, nghost)` inside build_cf_mask.
+  assert(cf_masks[s] && cf_masks[s]->nGrowVect() == ng);
   return cf_masks[s].get();
 }
 

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -376,16 +376,26 @@ struct GHExt {
       // and its distribution over all processes, but holds no data.
       std::unique_ptr<amrex::FabArrayBase> fab;
 
-      // Per-centering coarse-fine ghost masks, lazily built by get_cf_mask.
+      // Per-centering coarse-fine ghost masks, built single-threaded by
+      // build_cf_mask and read by get_cf_mask.
       // Indexed by (indextype[0]<<2)|(indextype[1]<<1)|indextype[2].
       mutable std::array<std::unique_ptr<amrex::iMultiFab>, 8> cf_masks;
 
-      // Returns the coarse-fine ghost mask for this (level, centering),
-      // building it on first request. Returns nullptr at level 0 or when
-      // subcycling is disabled.
+      // Returns the coarse-fine ghost mask for this (level, centering), or
+      // nullptr at level 0 / when subcycling is disabled. Pure reader,
+      // side-effect-free and safe to call from a parallel consume; callers MUST
+      // warm the centerings single-threaded via build_cf_mask first.
       amrex::iMultiFab *
       get_cf_mask(const std::array<int, dim> &indextype,
                   const std::array<int, dim> &nghostzones) const;
+
+      // Build and cache the coarse-fine ghost mask for this (level,
+      // centering). Idempotent; a no-op at level 0 / when subcycling is
+      // disabled. The only caller of iMultiFab::BuildMask, which opens its own
+      // OpenMP region, so this must run single-threaded (no active MFIter, no
+      // enclosing parallel region).
+      void build_cf_mask(const std::array<int, dim> &indextype,
+                         const std::array<int, dim> &nghostzones) const;
 
       cctkGHptr patch_cctkGH;
       std::vector<cctkGHptr> local_cctkGHs; // [component]

--- a/ODESolvers/src/odesolvers_solve_subcycling.cxx
+++ b/ODESolvers/src/odesolvers_solve_subcycling.cxx
@@ -166,6 +166,16 @@ extern "C" void ODESolvers_Solve_Subcycling(CCTK_ARGUMENTS) {
     statecomp_t::init_tmp_mfabs();
   }
 
+  // Warm the cf-mask cache single-threaded so the parallel calcys_rmbnd
+  // consume only reads it; building BuildMask's MFIter inside run_tasks's
+  // OpenMP region races AMReX's static MFIter::depth.
+  active_levels->loop_serially([&](const auto &leveldata) {
+    for (const int gi : var_groups) {
+      const auto &gd = *leveldata.groupdata.at(gi);
+      leveldata.build_cf_mask(gd.indextype, gd.nghostzones);
+    }
+  });
+
   const CCTK_REAL saved_time = cctkGH->cctk_time;
   const CCTK_REAL old_time = cctkGH->cctk_time - dt;
 
@@ -403,6 +413,15 @@ extern "C" void ODESolvers_Solve_Subcycling_Recovery(CCTK_ARGUMENTS) {
                                      ks_groups[s].data(), nullptr);
     }
   }
+
+  // Warm the cf-mask cache single-threaded before the parallel consume below
+  // (same rationale as ODESolvers_Solve_Subcycling).
+  active_levels->loop_serially([&](const auto &leveldata) {
+    for (const int gi : var_groups) {
+      const auto &gd = *leveldata.groupdata.at(gi);
+      leveldata.build_cf_mask(gd.indextype, gd.nghostzones);
+    }
+  });
 
   // calcys_rmbnd(1) body: fill refinement-boundary ghosts of var_groups.
   // xsi=0.5 and stage0=1 are the values calcys_rmbnd(1) would have computed

--- a/TestSubcyclingMC/schedule.ccl
+++ b/TestSubcyclingMC/schedule.ccl
@@ -32,6 +32,12 @@ SCHEDULE GROUP TestSubcyclingMC_RK4Group AT evol
 {
 } "RK4"
 
+SCHEDULE TestSubcyclingMC_WarmCFMask IN TestSubcyclingMC_RK4Group BEFORE TestSubcyclingMC_SetP
+{
+  LANG: C
+  OPTIONS: global
+} "Warm the coarse-fine ghost mask cache single-threaded before the parallel CalcK functions"
+
 SCHEDULE TestSubcyclingMC_SetP IN TestSubcyclingMC_RK4Group
 {
   LANG: C

--- a/TestSubcyclingMC/src/testsubcyclingmc.cxx
+++ b/TestSubcyclingMC/src/testsubcyclingmc.cxx
@@ -5,6 +5,7 @@
 #include <vect.hxx>
 
 #include "CarpetX/CarpetX/src/driver.hxx"
+#include "CarpetX/CarpetX/src/schedule.hxx"
 #include <cctk.h>
 #include <cctk_Arguments.h>
 #include <cctk_Parameters.h>
@@ -200,6 +201,21 @@ extern "C" void TestSubcyclingMC_CalcYfFromKcs(CCTK_ARGUMENTS,
       0.5 * (((cctkGH->cctk_iteration - 1) >> shift_amount) & 1);
   Subcycling::CalcYfFromKcs<4>(CCTK_PASS_CTOC, u_groups, p_groups, ks_groups,
                                dt * 2, xsi, stage);
+}
+
+extern "C" void TestSubcyclingMC_WarmCFMask(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+  if (!use_subcycling_wip)
+    return;
+  // Warm the cf-mask cache single-threaded before the parallel CalcK1..K4
+  // read it via CalcYfFromKcs; building it inside run_tasks's OpenMP region
+  // races AMReX's static MFIter::depth. Only the `ustate` centering is used.
+  const int gi = CCTK_GroupIndex("TestSubcyclingMC::ustate");
+  assert(CarpetX::active_levels);
+  CarpetX::active_levels->loop_serially([&](const auto &restrict leveldata) {
+    const auto &gd = *leveldata.groupdata.at(gi);
+    leveldata.build_cf_mask(gd.indextype, gd.nghostzones);
+  });
 }
 
 extern "C" void TestSubcyclingMC_SetP(CCTK_ARGUMENTS) {


### PR DESCRIPTION
Split the lazy get_cf_mask into build_cf_mask (single-threaded cache warming) and a side-effect-free get_cf_mask reader. Building the mask calls iMultiFab::BuildMask, which opens its own OpenMP region; doing that inside run_tasks's parallel consume races AMReX's static MFIter::depth. Callers now warm the cache single-threaded before the parallel consume: ODESolvers_Solve_Subcycling and its recovery variant via loop_serially, and TestSubcyclingMC via a new WarmCFMask scheduled before the CalcK functions.