### PR TITLE
CarpetX: call registered IO methods from OutputGH

### DIFF
--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -15,6 +15,7 @@
 
 #include <cctk.h>
 #include <cctk_Arguments.h>
+#include <cctk_IOMethods.h>
 #include <cctk_Parameters.h>
 #include <util_Table.h>
 
@@ -669,6 +670,17 @@ int OutputGH(const cGH *restrict cctkGH) {
     const int every = out_tsv_every == -1 ? out_every : out_tsv_every;
     if (every > 0 && cctk_iteration % every == 0)
       OutputTSV(cctkGH);
+  }
+
+  // Call the IO methods registered via CCTK_RegisterIOMethod; the flesh's
+  // default traversal never runs since CCTK_OutputGH is overloaded.
+  {
+    const int num_methods = CCTK_NumIOMethods();
+    for (int handle = 0; handle < num_methods; ++handle) {
+      const IOMethod *const method = CCTK_IOMethod(handle);
+      if (method && method->OutputGH)
+        method->OutputGH(cctkGH);
+    }
   }
 
   // Describe all output files


### PR DESCRIPTION
CarpetX overloads CCTK_OutputGH with its own OutputGH, which replaces the flesh's default behaviour of traversing the IO methods that other thorns register via CCTK_RegisterIOMethod. As a result, that standard Cactus extension point has been dead under CarpetX: an external IO thorn has no way to run at the output stage, i.e. after the CCTK_ANALYSIS traversal (a routine scheduled at POSTSTEP or ANALYSIS runs before, or in undefined order with, the analysis routines that compute derived quantities, and ANALYSIS is skipped on the recovery iteration).

Restore the traversal at the end of OutputGH: after all built-in writers (analysis-bin grid functions are up to date) and before OutputMeta (registered methods can describe their output files via OutputMeta_RegisterOutputFile). This is a no-op for configurations in which no thorn registers an IO method.

Note on classic IO thorns: thorns that register IO methods (e.g.
CactusBase's IOBasic or IOASCII), if activated and configured, will
start actually producing output under CarpetX, where previously their
registration was silently ignored. This is the intended Cactus
semantics being restored rather than a regression, but configurations
that activate such thorns "inertly" today will see new output files
after this change.