### PR TITLE
CarpetX: rebalance grid to current max_grid_size on recovery

### DIFF
--- a/CarpetX/param.ccl
+++ b/CarpetX/param.ccl
@@ -405,6 +405,16 @@ CCTK_INT regrid_every "Regridding interval" STEERABLE=always
   1:* :: "every that many iterations"
 } 0
 
+# When recovering from a checkpoint the box decomposition is read verbatim,
+# so a steered max_grid_size_* (e.g. tuned for a different node count) would
+# otherwise never take effect on a fixed grid (regrid_every = 0). Enabling
+# this re-chops every recovered level to the current max_grid_size and builds
+# a fresh load balance. The covered region per level is preserved exactly, so
+# the relayout is a pure data redistribution (bit-for-bit, no interpolation).
+BOOLEAN rebalance_on_recovery "Re-chop and load-balance the grid to the current max_grid_size after recovering from a checkpoint" STEERABLE=recover
+{
+} no
+
 #TODO: eliminate in favor of regrid_error being a true/false field
 CCTK_REAL regrid_error_threshold "Regridding error threshold" STEERABLE=always
 {

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1704,6 +1704,85 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
     CCTK_VINFO("RemakeLevel patch %d level %d done.", patch, level);
 }
 
+void CactusAmrCore::RedistributeLevel(const int level,
+                                      const amrex::BoxArray &ba,
+                                      const amrex::DistributionMapping &dm) {
+  DECLARE_CCTK_PARAMETERS;
+
+  if (verbose)
+#pragma omp critical
+    CCTK_VINFO("RedistributeLevel patch %d level %d", patch, level);
+
+  auto &patchdata = ghext->patchdata.at(patch);
+  auto &leveldata = patchdata.leveldata.at(level);
+
+  assert(ba.ixType() == amrex::IndexType(amrex::IndexType::CELL,
+                                         amrex::IndexType::CELL,
+                                         amrex::IndexType::CELL));
+
+  // The time bookkeeping of this level must survive the relayout. The
+  // LevelData constructor would otherwise reset it (level 0) or re-derive it
+  // from the coarser level (level > 0).
+  const rat64 saved_iteration = leveldata.iteration;
+  const rat64 saved_delta_iteration = leveldata.delta_iteration;
+  const bool saved_is_subcycling_level = leveldata.is_subcycling_level;
+
+  // Build a fresh LevelData (and hence fresh, empty MultiFabs and cctkGHs) on
+  // the new layout, then swap it in. The old LevelData lives on in the local
+  // variable so we can copy its data across before it is destroyed.
+  GHExt::PatchData::LevelData oldleveldata(
+      patch, level, ba, dm, []() { return "RedistributeLevel"; });
+  using std::swap;
+  swap(oldleveldata, leveldata);
+
+  leveldata.iteration = saved_iteration;
+  leveldata.delta_iteration = saved_delta_iteration;
+  leveldata.is_subcycling_level = saved_is_subcycling_level;
+
+  const amrex::Periodicity period =
+      patchdata.amrcore->Geom(level).periodicity();
+
+  const int num_groups = CCTK_NumGroups();
+  for (int gi = 0; gi < num_groups; ++gi) {
+    cGroup group;
+    int ierr = CCTK_GroupData(gi, &group);
+    assert(!ierr);
+
+    if (group.grouptype != CCTK_GF)
+      continue;
+
+    auto &restrict groupdata = *leveldata.groupdata.at(gi);
+    auto &restrict oldgroupdata = *oldleveldata.groupdata.at(gi);
+    assert(oldgroupdata.numvars == groupdata.numvars);
+
+    const int ntls = groupdata.mfab.size();
+    assert(int(oldgroupdata.mfab.size()) == ntls);
+
+    for (int tl = 0; tl < ntls; ++tl) {
+      amrex::MultiFab &newmfab = *groupdata.mfab.at(tl);
+      amrex::MultiFab &oldmfab = *oldgroupdata.mfab.at(tl);
+      assert(newmfab.nGrowVect() == oldmfab.nGrowVect());
+
+      // Pure relayout: old and new layouts cover an identical region (interior
+      // and, since the ghost width is unchanged, ghosts too), so a
+      // ghost-inclusive ParallelCopy reproduces every cell bit-for-bit. No
+      // interpolation, no boundary refill, no restriction is needed.
+      newmfab.ParallelCopy(oldmfab, 0, 0, groupdata.numvars,
+                           oldmfab.nGrowVect(), newmfab.nGrowVect(), period);
+    }
+
+    // The data is an exact copy of the old layout, so its validity (interior,
+    // outer, ghosts, per timelevel and variable) carries over verbatim.
+    groupdata.valid = oldgroupdata.valid;
+  }
+
+  level_modified.at(level) = true;
+
+  if (verbose)
+#pragma omp critical
+    CCTK_VINFO("RedistributeLevel patch %d level %d done.", patch, level);
+}
+
 void CactusAmrCore::ClearLevel(const int level) {
   DECLARE_CCTK_PARAMETERS;
 

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -110,6 +110,12 @@ public:
   virtual void RemakeLevel(int level, amrex::Real time,
                            const amrex::BoxArray &ba,
                            const amrex::DistributionMapping &dm) override;
+  // Redistribute an existing level onto a new (re-chopped, re-balanced)
+  // BoxArray/DistributionMapping without changing the covered region. Unlike
+  // RemakeLevel this performs no interpolation and works for level 0: the data
+  // is copied verbatim (all timelevels, ghosts included) from the old layout.
+  void RedistributeLevel(int level, const amrex::BoxArray &ba,
+                         const amrex::DistributionMapping &dm);
   virtual void ClearLevel(int level) override;
 };
 
@@ -181,7 +187,7 @@ struct GHExt {
                                         const AnyTypeScalarRef &scalar);
       };
 
-      AnyTypeVector() : _type(-1), _typesize(-1), _count(0), _data(nullptr) {};
+      AnyTypeVector() : _type(-1), _typesize(-1), _count(0), _data(nullptr){};
       AnyTypeVector(int type_, size_t count_)
           : _type(-1), _typesize(-1), _count(0), _data(nullptr) {
         alloc(type_, count_);

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -1084,6 +1084,100 @@ CCTK_REAL get_finest_mindx() {
   return mindx;
 }
 
+// Re-chop and load-balance every recovered level to the current
+// max_grid_size. With regrid_every = 0 the box decomposition read from the
+// checkpoint would otherwise be kept verbatim, so a steered max_grid_size
+// (e.g. tuned for a different node count) would never take effect. This
+// preserves the covered region of every level exactly and therefore only
+// redistributes data (RedistributeLevel copies it verbatim, no
+// interpolation) -- it works for level 0 / unigrid as well, which the AMReX
+// regrid path can never re-chop.
+void RebalanceAfterRecovery(cGH *restrict const cctkGH) {
+  DECLARE_CCTK_PARAMETERS;
+
+  static Timer timer("RebalanceAfterRecovery");
+  Interval interval(timer);
+
+#pragma omp critical
+  CCTK_VINFO("Rebalancing grid after recovery...");
+
+  // Determine the (possibly newly steered) max_grid_size for every level.
+  amrex::Vector<amrex::IntVect> max_grid_sizes_vec(20);
+  for (int level = 0; level < 20; ++level) {
+    int size_x = max_grid_sizes_x[level];
+    if (size_x == -1)
+      size_x = max_grid_size_x;
+    int size_y = max_grid_sizes_y[level];
+    if (size_y == -1)
+      size_y = max_grid_size_y;
+    int size_z = max_grid_sizes_z[level];
+    if (size_z == -1)
+      size_z = max_grid_size_z;
+    max_grid_sizes_vec.at(level) = amrex::IntVect{size_x, size_y, size_z};
+  }
+
+  int first_modified_level = INT_MAX;
+  int last_modified_level = -1;
+
+  for (auto &patchdata : ghext->patchdata) {
+    patchdata.amrcore->SetMaxGridSize(max_grid_sizes_vec);
+
+    const int numlevels = patchdata.amrcore->finestLevel() + 1;
+    patchdata.amrcore->level_modified.clear();
+    patchdata.amrcore->level_modified.resize(numlevels, false);
+
+    for (int level = 0; level < numlevels; ++level) {
+      // A value (the BoxArray is reference-counted, so this is cheap): the
+      // referenced fab is replaced by RedistributeLevel below, after which a
+      // reference into it would dangle.
+      const amrex::BoxArray old_ba =
+          patchdata.leveldata.at(level).fab->boxArray();
+
+      // Re-chop the recovered boxes to the current max_grid_size. simplify()
+      // first so that maxSize() can also *coarsen* an over-split decomposition
+      // (maxSize only ever splits boxes, it never merges them).
+      amrex::BoxList bl = old_ba.boxList();
+      bl.simplify();
+      amrex::BoxArray new_ba(std::move(bl));
+      new_ba.maxSize(max_grid_sizes_vec.at(level));
+
+      // Nothing to do if the decomposition is unchanged.
+      if (new_ba == old_ba)
+        continue;
+
+      amrex::DistributionMapping new_dm(new_ba);
+
+      // Keep the AmrCore's own view of the grids consistent, so that finer
+      // levels and AMReX internals see the new layout too.
+      patchdata.amrcore->SetBoxArray(level, new_ba);
+      patchdata.amrcore->SetDistributionMap(level, new_dm);
+
+      patchdata.amrcore->RedistributeLevel(level, new_ba, new_dm);
+
+      using std::max;
+      using std::min;
+      first_modified_level = min(first_modified_level, level);
+      last_modified_level = max(last_modified_level, level);
+
+#pragma omp critical
+      CCTK_VINFO("  patch %d level %d: %d -> %d boxes", patchdata.patch, level,
+                 int(old_ba.size()), int(new_ba.size()));
+    }
+  }
+
+  // Let downstream thorns (e.g. ODESolvers) rebuild any layout-dependent
+  // temporaries, mirroring the evolution-loop regrid.
+  const bool did_modify_any_level = last_modified_level >= first_modified_level;
+  if (did_modify_any_level) {
+    assert(!active_levels);
+    active_levels = make_optional<active_levels_t>(first_modified_level,
+                                                   last_modified_level + 1);
+    CCTK_Traverse(cctkGH, "CCTK_BASEGRID");
+    CCTK_Traverse(cctkGH, "CCTK_POSTREGRID");
+    active_levels = optional<active_levels_t>();
+  }
+}
+
 // Schedule initialisation
 int Initialise(tFleshConfig *config) {
   DECLARE_CCTK_PARAMETERS;
@@ -1201,6 +1295,12 @@ int Initialise(tFleshConfig *config) {
     ghext->recovered_level_iterations.clear();
 
     active_levels = optional<active_levels_t>();
+
+    // Re-chop and load-balance the recovered grid to the current
+    // max_grid_size. Required for the new max_grid_size to take effect when
+    // restarting on a different node count with a fixed grid (regrid_every=0).
+    if (rebalance_on_recovery)
+      RebalanceAfterRecovery(cctkGH);
 
     // Enable regridding
     for (auto &patchdata : ghext->patchdata)
@@ -2184,9 +2284,7 @@ int CallFunction(void *function, cFunctionData *restrict attribute,
     cFunctionData *const key = attribute;
     bool needs_check;
 #pragma omp critical(CarpetX_CallFunction)
-    {
-      needs_check = validated.insert(key).second;
-    }
+    { needs_check = validated.insert(key).second; }
     if (needs_check)
       check_storage_clauses(attribute);
   }


### PR DESCRIPTION
## Problem

With `regrid_every = 0` (fixed grid), the box decomposition read from a
checkpoint is kept **verbatim** for the entire restarted run — only the
*assignment* of those old boxes to ranks is recomputed. A `max_grid_size_*`
tuned for a different node count therefore never takes effect on restart:

- The new `max_grid_size` *is* applied to the `AmrCore`, but it only
  influences future `MakeNewGrids`/regrid calls, which never happen when
  `regrid_every = 0`.
- Scaling up beyond the checkpointed box count leaves excess ranks idle,
  because the SFC balance can only redistribute at the granularity of the
  **old** boxes.
- Even with `regrid_every > 0`, `AmrCore::regrid(lbase, …)` only rebuilds
  levels `lbase+1` and finer — **level 0 is never re-chopped**, so a unigrid
  run's decomposition is permanent.

## Fix

Add a `rebalance_on_recovery` parameter (`BOOLEAN`, `STEERABLE=recover`,
default `no`). When enabled, after recovery completes CarpetX re-chops every
recovered level to the **current** `max_grid_size` and builds a fresh
`DistributionMapping`.

Because the covered region of each level is identical by construction
(`BoxList::simplify()` to allow coarsening, then `BoxArray::maxSize()` to
re-chop), this is a pure data **redistribution**, not a regrid:

- New `CactusAmrCore::RedistributeLevel` builds a fresh `LevelData` on the
  new layout and copies **all** timelevels (ghosts included) verbatim via a
  ghost-inclusive `amrex::MultiFab::ParallelCopy`. No interpolation, no
  boundary refill, no restriction — the copy is bit-for-bit and the validity
  flags carry over unchanged.
- Unlike the AMReX regrid path, this works for **level 0 / unigrid** — exactly
  the fixed-grid scenario that motivated the change — and preserves the oldest
  timelevel (which `RemakeLevel` deliberately does not prolongate).
- `SetBoxArray`/`SetDistributionMap` keep the `AmrCore`'s own grid view
  consistent so finer levels and AMReX internals see the new layout. Levels are
  processed coarse→fine; levels whose chopping is unchanged are skipped.
- A `CCTK_BASEGRID` / `CCTK_POSTREGRID` traverse over the modified levels lets
  downstream thorns recompute layout-dependent state, mirroring the
  evolution-loop regrid.

This implements the design from the analysis notes (a uniform "Option B"
relayout applied to every level, which subsumes the hybrid recommendation: it
is simpler and more correct than reusing `AmrCore::regrid` for levels ≥ 1,
since it preserves covered regions and all timelevels exactly).

## Files

- `CarpetX/param.ccl` — new `rebalance_on_recovery` parameter.
- `CarpetX/src/driver.{hxx,cxx}` — `RedistributeLevel`.
- `CarpetX/src/schedule.cxx` — `RebalanceAfterRecovery` driver, invoked from the
  recovery branch of `Initialise` after the per-level iteration restore and
  before regridding is enabled.

## Testing

The remote session does not have the build container env vars
(`CONTAINERLOCAL*`) available, so I could **not** compile or run the test suite
here. The change has only been reviewed statically. Before merging it should be
built (`./agent_scripts/build.sh`) and exercised with the intended scenario:
checkpoint at N ranks with one `max_grid_size`, restart at M ranks with another,
and compare against an unsplit evolution (tolerances loose enough for
reduction-order differences in downstream reductions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxEoXYVJN4anY3k94Uv5Vq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEoXYVJN4anY3k94Uv5Vq)_