### PR TITLE
ODESolvers: rewrite SSPRK3 in low-storage Shu-Osher form

### DIFF
--- a/ODESolvers/src/odesolvers_solve.cxx
+++ b/ODESolvers/src/odesolvers_solve.cxx
@@ -200,25 +200,23 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
 
   } else if (CCTK_EQUALS(method, "SSPRK3")) {
 
-    // k1 = f(y0)
-    // k2 = f(y0 + h k1)
-    // k3 = f(y0 + h/4 k1 + h/4 k2)
-    // y1 = y0 + h/6 k1 + h/6 k2 + 2/3 h k3
+    // Low-storage Shu-Osher form (Shu & Osher 1988):
+    //   u1 = u0 + h L(u0)
+    //   u2 = 3/4 u0 + 1/4 u1 + 1/4 h L(u1)
+    //   u3 = 1/3 u0 + 2/3 u2 + 2/3 h L(u2)
 
     const auto old = copy_state(var, make_valid_all());
 
     calcrhs(1);
-    const auto k1 = copy_state(rhs, make_valid_int());
-    calcupdate(1, dt, 1.0, reals<1>{dt}, states<1>{&k1});
+    calcupdate(1, dt, 1.0, reals<1>{dt}, states<1>{&rhs});
 
     calcrhs(2);
-    const auto k2 = copy_state(rhs, make_valid_int());
-    calcupdate(2, dt / 2, 0.0, reals<3>{1.0, dt / 4, dt / 4},
-               states<3>{&old, &k1, &k2});
+    calcupdate(2, dt / 2, 1.0 / 4.0, reals<2>{3.0 / 4.0, dt / 4},
+               states<2>{&old, &rhs});
 
     calcrhs(3);
-    calcupdate(3, dt, 0.0, reals<4>{1.0, dt / 6, dt / 6, 2 * dt / 3},
-               states<4>{&old, &k1, &k2, &rhs});
+    calcupdate(3, dt, 2.0 / 3.0, reals<2>{1.0 / 3.0, 2 * dt / 3},
+               states<2>{&old, &rhs});
 
   } else if (CCTK_EQUALS(method, "RK4")) {
 


### PR DESCRIPTION
## The fix

The non-subcycling `SSPRK3` integrator branch is rewritten from the Butcher k-form into its algebraically-identical low-storage Shu-Osher form (Shu & Osher 1988):

```
u1 = u0 + h L(u0)
u2 = 3/4 u0 + 1/4 u1 + 1/4 h L(u1)
u3 = 1/3 u0 + 2/3 u2 + 2/3 h L(u2)
```

This eliminates the two whole-hierarchy RHS-sized copies (`k1`, `k2`). Peak live full-hierarchy state-sized objects in the non-subcycling SSPRK3 path drop from **5 → 3** (`var`, `rhs`, `old`); only `old` is copied now.

The numerical scheme is **unchanged**: same third-order accuracy, same stability region. Compute cost per step is essentially unchanged — same three RHS evaluations and three `lincomb` updates, with two fewer `copy` operations.

This resolves the `HSA_STATUS_ERROR_OUT_OF_RESOURCES` / `Available Free mem : 0 MB` abort seen running `BBHCloud_10lvl_nocool_N125.par` with `method = "SSPRK3"` and default (non-subcycling) evolution on Frontier GPUs, which was driven by the peak memory of the five whole-hierarchy temporaries across all 10 refinement levels.

## Tests run

- `./agent_scripts/test.sh` — full suite passes (90 passed, 0 failed).
- `TestODESolvers2/test-ssprk3` — convergence order 3 retained (`order=3.0001`) against the existing checked-in reference data; no reference regeneration needed.

## Operator fallbacks (NOT the fix)

Immediate, no-rebuild mitigations available to users. These are **operator fallbacks**, not the fix, and they corroborate the memory-pressure diagnosis — every lower-peak configuration succeeds:

- `CarpetX::use_subcycling = yes` (which also forces `restrict_during_sync = no`) — advances one level-batch per call and never holds whole-hierarchy temporaries at once.
- Switch to a lower-storage method: `RK4` (peak 4), `RK2` (peak 3), or `Euler` (peak 2).
- Reduce refinement levels / use coarser grids to shrink each whole-hierarchy object.
