### PR TITLE
CarpetX: add par rechop_on_recovery

### DIFF
--- a/CarpetX/param.ccl
+++ b/CarpetX/param.ccl
@@ -531,6 +531,10 @@ KEYWORD recover_method "I/O method for recovery" STEERABLE=recover
   "silo" :: ""
 } "error"
 
+BOOLEAN rechop_on_recovery "Re-chop and load-balance all levels to the current max_grid_size when recovering from a checkpoint (openPMD only)" STEERABLE=recover
+{
+} "no"
+
 KEYWORD checkpoint_method "I/O method for checkpointing" STEERABLE=recover
 {
   "error" :: "Abort with error instead of checkpointing"

--- a/CarpetX/schedule.ccl
+++ b/CarpetX/schedule.ccl
@@ -18,6 +18,15 @@ if (!CCTK_Equals(recover, "no") && *recover_file)
   } "Recover parameters"
 }
 
+if (rechop_on_recovery)
+{
+  SCHEDULE CarpetX_CheckRechopParameters AT CCTK_PARAMCHECK
+  {
+    LANG: C
+    OPTIONS: global
+  } "Reject rechop_on_recovery with the Silo recovery backend"
+}
+
 
 
 # I/O

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1130,6 +1130,38 @@ std::string subcycling_band_tag(const band_kind kind, const int stage) {
   return buf.str();
 }
 
+amrex::BoxArray rechop_boxarray(const amrex::BoxArray &ba,
+                                const amrex::IntVect &max_grid_size,
+                                const amrex::IntVect &chop_unit,
+                                const bool refine_grid_layout,
+                                const int nranks) {
+  amrex::BoxList bl = ba.boxList();
+  bl.simplify(true); // merge boxes
+  bl.coarsen(chop_unit);
+
+  amrex::IntVect chunk = max_grid_size / chop_unit;
+  chunk.max(amrex::IntVect(1));
+  bl.maxSize(chunk);
+
+  if (refine_grid_layout) {
+    // Halve the largest chunk dimension toward one box per rank
+    // (cf. AmrMesh::ChopGrids)
+    while (int(bl.size()) < nranks) {
+      int idim = -1;
+      for (int d = 0; d < dim; ++d)
+        if (chunk[d] >= 2 && (idim < 0 || chunk[d] > chunk[idim]))
+          idim = d;
+      if (idim < 0)
+        break;
+      chunk[idim] /= 2;
+      bl.maxSize(chunk);
+    }
+  }
+
+  bl.refine(chop_unit);
+  return amrex::BoxArray(std::move(bl));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void GHExt::PatchData::LevelData::GroupData::init_tmp_mfabs() const {

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -601,6 +601,16 @@ enum class band_kind { ks_consumer, old_consumer };
 // for ks_consumer, "oldc" for old_consumer. Shared by both IO backends.
 std::string subcycling_band_tag(band_kind kind, int stage = -1);
 
+// Union-preserving re-chop of a level's BoxArray: merge the boxes, re-split
+// to max_grid_size, and halve chunks toward nranks boxes if
+// refine_grid_layout. All cuts are aligned to chop_unit; the caller must
+// verify that the union is unchanged (it is not if the input boxes are not
+// chop_unit-aligned).
+amrex::BoxArray rechop_boxarray(const amrex::BoxArray &ba,
+                                const amrex::IntVect &max_grid_size,
+                                const amrex::IntVect &chop_unit,
+                                bool refine_grid_layout, int nranks);
+
 } // namespace CarpetX
 
 #endif // #ifndef CARPETX_CARPETX_DRIVER_HXX

--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -143,6 +143,18 @@ extern "C" int CarpetX_RecoverParameters() {
   return recover_iteration >= 0;
 }
 
+extern "C" void CarpetX_CheckRechopParameters(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+
+  if (rechop_on_recovery && CCTK_EQUALS(recover_method, "silo") &&
+      !CCTK_EQUALS(recover, "no"))
+    CCTK_PARAMWARN(
+        "CarpetX::rechop_on_recovery is not supported with "
+        "CarpetX::recover_method = \"silo\": the Silo reader is tied to the "
+        "checkpointed box decomposition. Use openPMD checkpoints "
+        "(CarpetX::recover_method = \"openpmd\") to re-chop on recovery.");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void RecoverGridStructure(cGH *restrict cctkGH) {

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -682,6 +682,38 @@ void carpetx_openpmd_t::InputOpenPMDGridStructure(cGH *cctkGH,
 
       amrex::BoxList boxlist(std::move(levboxes));
       amrex::BoxArray boxarray(std::move(boxlist));
+
+      if (rechop_on_recovery) {
+        // Keep cuts aligned to the blocking factor and, on fine levels, the
+        // refinement ratio
+        amrex::IntVect chop_unit = patchdata.amrcore->blockingFactor(level);
+        if (level > 0)
+          chop_unit.max(patchdata.amrcore->refRatio(level - 1));
+        const amrex::BoxArray old_boxarray = boxarray;
+        boxarray = rechop_boxarray(
+            old_boxarray, patchdata.amrcore->maxGridSize(level), chop_unit,
+            refine_grid_layout, amrex::ParallelDescriptor::NProcs());
+        if (boxarray.numPts() != old_boxarray.numPts() ||
+            !boxarray.contains(old_boxarray) ||
+            !old_boxarray.contains(boxarray))
+          CCTK_VERROR(
+              "rechop_on_recovery changed the grid coverage on patch %d "
+              "level %d. This can happen when the checkpointed boxes are not "
+              "aligned with the current blocking factor; restart with the "
+              "checkpoint's blocking_factor_[xyz] or disable "
+              "rechop_on_recovery.",
+              patchdata.patch, level);
+        if (io_verbose)
+          CCTK_VINFO("Re-chopped patch %d level %d: %d boxes -> %d boxes "
+                     "(max_grid_size [%d,%d,%d], %d processes)",
+                     patchdata.patch, level, int(old_boxarray.size()),
+                     int(boxarray.size()),
+                     int(patchdata.amrcore->maxGridSize(level)[0]),
+                     int(patchdata.amrcore->maxGridSize(level)[1]),
+                     int(patchdata.amrcore->maxGridSize(level)[2]),
+                     amrex::ParallelDescriptor::NProcs());
+      }
+
       patchdata.amrcore->SetBoxArray(level, boxarray);
 
       amrex::DistributionMapping dm(boxarray);

--- a/CarpetX/src/io_silo.cxx
+++ b/CarpetX/src/io_silo.cxx
@@ -335,6 +335,10 @@ void InputSiloGridStructure(cGH *restrict const cctkGH,
   assert(!input_file.empty());
   assert(input_iteration >= 0);
 
+  if (rechop_on_recovery)
+    CCTK_VERROR("CarpetX::rechop_on_recovery is not supported with the Silo "
+                "recovery backend; use openPMD checkpoints instead");
+
   int ierr;
 
   // Set up timers


### PR DESCRIPTION
When recovering from an openPMD checkpoint, optionally re-chop and load-balance all levels to the current max_grid_size instead of keeping the checkpointed box decomposition. The re-chop is union-preserving: boxes are merged, re-split with cuts aligned to the blocking factor (and refinement ratio on fine levels), and halved toward one box per rank if refine_grid_layout. Recovery aborts if the coverage would change.

The Silo reader is tied to the checkpointed decomposition, so the parameter is rejected at paramcheck for recover_method = "silo".