### PR TITLE
CarpetX: 2 bugs in the reduction API: combine functor drops its left operand; reduction_mpi_datatype_CCTK_REAL is undefined

### DIFF
--- a/CarpetX/src/reduction.cxx
+++ b/CarpetX/src/reduction.cxx
@@ -34,6 +34,10 @@ template <typename T, int D> MPI_Datatype reduction_mpi_datatype() {
   return datatype;
 }
 
+MPI_Datatype reduction_mpi_datatype_CCTK_REAL() {
+  return reduction_mpi_datatype<CCTK_REAL, dim>();
+}
+
 namespace {
 template <typename T>
 void mpi_reduce_typed(const void *restrict x0, void *restrict y0,

--- a/CarpetX/src/reduction.hxx
+++ b/CarpetX/src/reduction.hxx
@@ -117,7 +117,7 @@ template <typename T, int D> struct combine {
   }
   constexpr AMREX_GPU_DEVICE value_type operator()(const value_type &x,
                                                    const value_type &y) const {
-    return (value_type)reduction<T, D>(x), reduction<T, D>(y);
+    return (value_type)reduction<T, D>(reduction<T, D>(x), reduction<T, D>(y));
   }
 };
 


### PR DESCRIPTION
This PR fixes two small bugs in CarpetX's reduction API that affect external
consumers (e.g. analysis thorns building on `reduction<T, dim>` /
`amrex::ParReduce`).

## 1. `combine::operator()` discards its left operand

`combine::operator()` in `reduction.hxx` read

    return (value_type)reduction<T, D>(x), reduction<T, D>(y);

which is a comma expression: the cast of `x` is evaluated and discarded, and
`y` is returned unmerged. Any GPU reduction using this functor (its intended
purpose as the `ParReduce` combine over `reduction::tuple_type`) silently
loses every left-hand partial result. The bug is currently latent — nothing
in-tree instantiates `combine<>` yet — but it breaks the first real consumer.

Fixed by merging through the existing combining constructor:

    return (value_type)reduction<T, D>(reduction<T, D>(x), reduction<T, D>(y));

## 2. `reduction_mpi_datatype_CCTK_REAL()` declared but never defined

`reduction.hxx` declares `MPI_Datatype reduction_mpi_datatype_CCTK_REAL();`,
but no translation unit defines it (`reduction.cxx` uses the internal
`reduction_mpi_datatype<T, D>()` template directly). Any external caller of
the declared function hits an undefined reference at link time and has to
re-implement the datatype construction by hand.

Fixed by adding the definition in `reduction.cxx`, delegating to
`reduction_mpi_datatype<CCTK_REAL, dim>()`.

Both changes are behavior-preserving for all existing in-tree code paths
(no current callers of either symbol).