### PR TITLE
ci: skip Claude code review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip fork PRs: GitHub does not provision OIDC tokens for pull_request
+    # runs from forks, so the action cannot authenticate and fails.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
GitHub does not provision OIDC tokens for pull_request runs from forks, so the review action cannot authenticate and the job always fails. Skip the job unless the PR branch lives in this repository.